### PR TITLE
test_cafe: don't assume current working directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mora",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OS2 Mennesker + Organisation 2.0",
   "author": "Magenta ApS <info@magenta.dk>",
   "private": true,

--- a/tests/test_cafe.py
+++ b/tests/test_cafe.py
@@ -49,7 +49,8 @@ class TestCafeTests(util.LiveLoRATestCase):
 
         process = subprocess.run(
             [
-                "node_modules/.bin/testcafe",
+                os.path.join(util.BASE_DIR,
+                             "node_modules", ".bin", "testcafe"),
                 "'{} --no-sandbox'".format(browser),
                 self.TEST_DIR,
                 "-r", ','.join(["spec",


### PR DESCRIPTION
This is likely what broke the LoRA test suite — and since we're doing
this in a hotfix, bump the version.