### PR TITLE
#24077 access address

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,8 @@ Bug fixes
   possesses as vacant rather than terminating them.
 * #24069: Handle DAR address errors gracefully, displaying the error
   message rather than suppressing all addresses.
+* #24077: Allow entering DAR access addresses as well as regular
+  adresses in all fields, and allow reading historical addresses.
 
 Known bugs
 ----------

--- a/backend/mora/service/address.py
+++ b/backend/mora/service/address.py
@@ -662,11 +662,13 @@ def address_autocomplete(orgid):
 
     addrs = requests.get(
         'https://dawa.aws.dk/adresser/autocomplete',
-        params={
-            'noformat': '1',
-            'kommunekode': code,
-            'q': q,
-        },
+        # use a list to work around unordered dicts in Python < 3.6
+        params=[
+            ('per_side', '10'),
+            ('noformat', '1'),
+            ('kommunekode', code),
+            ('q', q),
+        ],
     ).json()
 
     return flask.jsonify([

--- a/backend/mora/service/address.py
+++ b/backend/mora/service/address.py
@@ -212,6 +212,7 @@ from .. import common
 from .. import exceptions
 from .. import lora
 from .. import mapping
+from .. import settings
 from .. import util
 
 session = requests.Session()
@@ -733,7 +734,7 @@ def address_autocomplete(orgid):
             'https://dawa.aws.dk/adgangsadresser/autocomplete',
             # use a list to work around unordered dicts in Python < 3.6
             params=[
-                ('per_side', '5'),
+                ('per_side', settings.AUTOCOMPLETE_ACCESS_ADDRESS_COUNT),
                 ('noformat', '1'),
                 ('kommunekode', code),
                 ('q', q),
@@ -745,7 +746,7 @@ def address_autocomplete(orgid):
         'https://dawa.aws.dk/adresser/autocomplete',
         # use a list to work around unordered dicts in Python < 3.6
         params=[
-            ('per_side', '10'),
+            ('per_side', settings.AUTOCOMPLETE_ADDRESS_COUNT),
             ('noformat', '1'),
             ('kommunekode', code),
             ('q', q),

--- a/backend/mora/service/address.py
+++ b/backend/mora/service/address.py
@@ -9,12 +9,16 @@
 ---------
 .. _address:
 
-
 Within the context of MO, we have two forms of addresses, `DAR`_ and
 everything else. **DAR** is short for *Danmarks Adresseregister* or
 the *Address Register of Denmark*, and constitutes a UUID representing a
 DAWA address or access address. We represent other addresses merely
 through their textual value.
+
+.. tip::
+
+  See also the `official documentation
+  <http://dawa.aws.dk/dok/adresser>`_ — in Danish — on DAR addresses.
 
 Before writing a DAR address, a UI or client should convert the
 address string to a UUID using either their API or the
@@ -189,7 +193,7 @@ units.
 
 
 API
-~~~
+^^^
 
 '''
 
@@ -654,7 +658,9 @@ def get_scope_and_original(obj_uuid, obj_type):
 @blueprint.route('/o/<uuid:orgid>/address_autocomplete/')
 @util.restrictargs('global', required=['q'])
 def address_autocomplete(orgid):
-    """Perform address autocomplete
+    """Perform address autocomplete, resolving both ``adgangsadresse`` and
+    ``adresse``.
+
     :param orgid: The UUID of the organisation
 
     .. :quickref: Address; Autocomplete

--- a/backend/mora/settings.py
+++ b/backend/mora/settings.py
@@ -19,6 +19,10 @@ DEFAULT_PAGE_SIZE = 2000
 LORA_URL = 'http://mox.lxc/'
 CA_BUNDLE = None
 
+# for our autocomplete support
+AUTOCOMPLETE_ACCESS_ADDRESS_COUNT = 5
+AUTOCOMPLETE_ADDRESS_COUNT = 10
+
 # Session config
 SESSION_TYPE = 'filesystem'
 SESSION_PERMANENT = False

--- a/backend/tests/mocking/aabogade.json
+++ b/backend/tests/mocking/aabogade.json
@@ -1,123 +1,21 @@
 {
-  "https://dawa.aws.dk/adresser/44c532e1-f617-4174-b144-d37ce9fda2bd?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6225_573",
-        "km10": "10km_622_57",
-        "m100": "100m_62258_5737"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 68,
-        "id": "0a3f5097-3260-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          10.18779751,
-          56.17233057
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TD",
-        "tekstretning": 318,
-        "\u00e6ndret": "2016-09-07T00:00:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/12337669-a188-6b98-e053-d480220a5a3f",
-          "id": "12337669-a188-6b98-e053-d480220a5a3f",
-          "kode": 11045,
-          "navn": "Aarhus",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2006353,
-        "navn": "\u00c5rhus Markjorder"
-      },
-      "esrejendomsnr": "562276",
-      "historik": {
-        "oprettet": "2000-02-05T15:30:10.000",
-        "\u00e6ndret": "2016-09-07T09:25:55.310"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f5097-3260-32b8-e044-0003ba298018",
+  "https://dawa.aws.dk/adresser?id=44c532e1-f617-4174-b144-d37ce9fda2bd&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f5097-3260-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "\u00c5bogade",
+      "d\u00f8r": null,
+      "etage": null,
       "husnr": "15",
-      "id": "0a3f5097-3260-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2006353",
-          "kode": 2006353,
-          "navn": "\u00c5rhus Markjorder"
-        },
-        "esrejendomsnr": "562276",
-        "href": "https://dawa.aws.dk/jordstykker/2006353/117ki",
-        "matrikelnr": "117ki"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0751",
-        "kode": "0751",
-        "navn": "Aarhus"
-      },
-      "kvh": "07519651__15",
-      "matrikelnr": "117ki",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/64",
-        "kode": "0064",
-        "navn": "Aarhus Nord"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1461",
-        "kode": "1461",
-        "navn": "\u00d8stjyllands Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/8200",
-        "navn": "Aarhus N",
-        "nr": "8200"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1082",
-        "kode": "1082",
-        "navn": "Region Midtjylland"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1165",
-        "kode": "1165",
-        "navn": "Retten i \u00c5rhus"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/8121",
-        "kode": "8121",
-        "navn": "Christians"
-      },
+      "id": "44c532e1-f617-4174-b144-d37ce9fda2bd",
+      "kommunekode": "0751",
+      "postnr": "8200",
+      "postnrnavn": "Aarhus N",
       "status": 1,
-      "stormodtagerpostnummer": null,
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "1bd35784-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          10.18800013,
-          56.17230413
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V0"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "\u00c5bogade",
-        "href": "https://dawa.aws.dk/vejstykker/751/9651",
-        "kode": "9651",
-        "navn": "\u00c5bogade"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "\u00c5bogade 15, 8200 Aarhus N",
-    "d\u00f8r": null,
-    "etage": null,
-    "historik": {
-      "oprettet": "2014-05-05T19:07:48.577",
-      "\u00e6ndret": "2014-05-05T19:07:48.577"
-    },
-    "href": "https://dawa.aws.dk/adresser/44c532e1-f617-4174-b144-d37ce9fda2bd",
-    "id": "44c532e1-f617-4174-b144-d37ce9fda2bd",
-    "kvhx": "07519651__15_______",
-    "status": 1
-  }
+      "vejkode": "9651",
+      "vejnavn": "\u00c5bogade",
+      "x": 10.18779751,
+      "y": 56.17233057
+    }
+  ]
 }

--- a/backend/tests/mocking/dawa-addresses.json
+++ b/backend/tests/mocking/dawa-addresses.json
@@ -1,860 +1,135 @@
 {
-  "https://dawa.aws.dk/adresser/0a3f50a0-23c9-32b8-e044-0003ba298018?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6176_725",
-        "km10": "10km_617_72",
-        "m100": "100m_61763_7250"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 4.9,
-        "id": "0a3f507a-da84-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          12.57924839,
-          55.68113676
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TD",
-        "tekstretning": 200,
-        "\u00e6ndret": "2002-04-05T00:00:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/12337669-d99e-6b98-e053-d480220a5a3f",
-          "id": "12337669-d99e-6b98-e053-d480220a5a3f",
-          "kode": null,
-          "navn": "Indre By",
-          "type": "bydel"
-        },
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/290f85b8-8c7a-6fd1-e053-d480220af996",
-          "id": "290f85b8-8c7a-6fd1-e053-d480220af996",
-          "kode": 18368,
-          "navn": "K\u00f8benhavn",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2000162,
-        "navn": "K\u00f8bmager Kvarter, K\u00f8benhavn"
-      },
-      "esrejendomsnr": "436756",
-      "historik": {
-        "oprettet": "2000-02-05T20:30:37.000",
-        "\u00e6ndret": "2009-11-25T01:07:37.000"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f507a-da84-32b8-e044-0003ba298018",
+  "https://dawa.aws.dk/adresser?id=0a3f50a0-23c9-32b8-e044-0003ba298018&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f507a-da84-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "Pilestr\u00e6de",
+      "d\u00f8r": null,
+      "etage": "3",
       "husnr": "43",
-      "id": "0a3f507a-da84-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2000162",
-          "kode": 2000162,
-          "navn": "K\u00f8bmager Kvarter, K\u00f8benhavn"
-        },
-        "esrejendomsnr": "436756",
-        "href": "https://dawa.aws.dk/jordstykker/2000162/80",
-        "matrikelnr": "80"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0101",
-        "kode": "0101",
-        "navn": "K\u00f8benhavn"
-      },
-      "kvh": "01015520__43",
-      "matrikelnr": "80",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/3",
-        "kode": "0003",
-        "navn": "Indre By"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1470",
-        "kode": "1470",
-        "navn": "K\u00f8benhavns Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/1112",
-        "navn": "K\u00f8benhavn K",
-        "nr": "1112"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1084",
-        "kode": "1084",
-        "navn": "Region Hovedstaden"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1101",
-        "kode": "1101",
-        "navn": "K\u00f8benhavns Byret"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/7002",
-        "kode": "7002",
-        "navn": "Hellig\u00e5nds"
-      },
+      "id": "0a3f50a0-23c9-32b8-e044-0003ba298018",
+      "kommunekode": "0101",
+      "postnr": "1112",
+      "postnrnavn": "K\u00f8benhavn K",
       "status": 1,
-      "stormodtagerpostnummer": null,
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "11edb085-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          12.57930359,
-          55.68119065
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V0"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "Pilestr\u00e6de",
-        "href": "https://dawa.aws.dk/vejstykker/101/5520",
-        "kode": "5520",
-        "navn": "Pilestr\u00e6de"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "Pilestr\u00e6de 43, 3., 1112 K\u00f8benhavn K",
-    "d\u00f8r": null,
-    "etage": "3",
-    "historik": {
-      "oprettet": "2000-02-05T20:30:37.000",
-      "\u00e6ndret": "2000-02-05T20:30:37.000"
-    },
-    "href": "https://dawa.aws.dk/adresser/0a3f50a0-23c9-32b8-e044-0003ba298018",
-    "id": "0a3f50a0-23c9-32b8-e044-0003ba298018",
-    "kvhx": "01015520__43__3____",
-    "status": 1
-  },
-  "https://dawa.aws.dk/adresser/44c532e1-f617-4174-b144-d37ce9fda2bd?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6225_573",
-        "km10": "10km_622_57",
-        "m100": "100m_62258_5737"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 68,
-        "id": "0a3f5097-3260-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          10.18779751,
-          56.17233057
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TD",
-        "tekstretning": 318,
-        "\u00e6ndret": "2016-09-07T00:00:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/12337669-a188-6b98-e053-d480220a5a3f",
-          "id": "12337669-a188-6b98-e053-d480220a5a3f",
-          "kode": 11045,
-          "navn": "Aarhus",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2006353,
-        "navn": "\u00c5rhus Markjorder"
-      },
-      "esrejendomsnr": "562276",
-      "historik": {
-        "oprettet": "2000-02-05T15:30:10.000",
-        "\u00e6ndret": "2016-09-07T09:25:55.310"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f5097-3260-32b8-e044-0003ba298018",
+      "vejkode": "5520",
+      "vejnavn": "Pilestr\u00e6de",
+      "x": 12.57924839,
+      "y": 55.68113676
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=44c532e1-f617-4174-b144-d37ce9fda2bd&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f5097-3260-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "\u00c5bogade",
+      "d\u00f8r": null,
+      "etage": null,
       "husnr": "15",
-      "id": "0a3f5097-3260-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2006353",
-          "kode": 2006353,
-          "navn": "\u00c5rhus Markjorder"
-        },
-        "esrejendomsnr": "562276",
-        "href": "https://dawa.aws.dk/jordstykker/2006353/117ki",
-        "matrikelnr": "117ki"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0751",
-        "kode": "0751",
-        "navn": "Aarhus"
-      },
-      "kvh": "07519651__15",
-      "matrikelnr": "117ki",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/64",
-        "kode": "0064",
-        "navn": "Aarhus Nord"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1461",
-        "kode": "1461",
-        "navn": "\u00d8stjyllands Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/8200",
-        "navn": "Aarhus N",
-        "nr": "8200"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1082",
-        "kode": "1082",
-        "navn": "Region Midtjylland"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1165",
-        "kode": "1165",
-        "navn": "Retten i \u00c5rhus"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/8121",
-        "kode": "8121",
-        "navn": "Christians"
-      },
+      "id": "44c532e1-f617-4174-b144-d37ce9fda2bd",
+      "kommunekode": "0751",
+      "postnr": "8200",
+      "postnrnavn": "Aarhus N",
       "status": 1,
-      "stormodtagerpostnummer": null,
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "1bd35784-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          10.18800013,
-          56.17230413
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V0"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "\u00c5bogade",
-        "href": "https://dawa.aws.dk/vejstykker/751/9651",
-        "kode": "9651",
-        "navn": "\u00c5bogade"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "\u00c5bogade 15, 8200 Aarhus N",
-    "d\u00f8r": null,
-    "etage": null,
-    "historik": {
-      "oprettet": "2014-05-05T19:07:48.577",
-      "\u00e6ndret": "2014-05-05T19:07:48.577"
-    },
-    "href": "https://dawa.aws.dk/adresser/44c532e1-f617-4174-b144-d37ce9fda2bd",
-    "id": "44c532e1-f617-4174-b144-d37ce9fda2bd",
-    "kvhx": "07519651__15_______",
-    "status": 1
-  },
-  "https://dawa.aws.dk/adresser/606cf42e-9dc2-4477-bf70-594830fcbdec?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6225_573",
-        "km10": "10km_622_57",
-        "m100": "100m_62258_5737"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 68,
-        "id": "0a3f5097-3260-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          10.18779751,
-          56.17233057
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TD",
-        "tekstretning": 318,
-        "\u00e6ndret": "2016-09-07T00:00:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/12337669-a188-6b98-e053-d480220a5a3f",
-          "id": "12337669-a188-6b98-e053-d480220a5a3f",
-          "kode": 11045,
-          "navn": "Aarhus",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2006353,
-        "navn": "\u00c5rhus Markjorder"
-      },
-      "esrejendomsnr": "562276",
-      "historik": {
-        "oprettet": "2000-02-05T15:30:10.000",
-        "\u00e6ndret": "2016-09-07T09:25:55.310"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f5097-3260-32b8-e044-0003ba298018",
+      "vejkode": "9651",
+      "vejnavn": "\u00c5bogade",
+      "x": 10.18779751,
+      "y": 56.17233057
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=606cf42e-9dc2-4477-bf70-594830fcbdec&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f5097-3260-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "\u00c5bogade",
+      "d\u00f8r": null,
+      "etage": "1",
       "husnr": "15",
-      "id": "0a3f5097-3260-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2006353",
-          "kode": 2006353,
-          "navn": "\u00c5rhus Markjorder"
-        },
-        "esrejendomsnr": "562276",
-        "href": "https://dawa.aws.dk/jordstykker/2006353/117ki",
-        "matrikelnr": "117ki"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0751",
-        "kode": "0751",
-        "navn": "Aarhus"
-      },
-      "kvh": "07519651__15",
-      "matrikelnr": "117ki",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/64",
-        "kode": "0064",
-        "navn": "Aarhus Nord"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1461",
-        "kode": "1461",
-        "navn": "\u00d8stjyllands Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/8200",
-        "navn": "Aarhus N",
-        "nr": "8200"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1082",
-        "kode": "1082",
-        "navn": "Region Midtjylland"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1165",
-        "kode": "1165",
-        "navn": "Retten i \u00c5rhus"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/8121",
-        "kode": "8121",
-        "navn": "Christians"
-      },
+      "id": "606cf42e-9dc2-4477-bf70-594830fcbdec",
+      "kommunekode": "0751",
+      "postnr": "8200",
+      "postnrnavn": "Aarhus N",
       "status": 1,
-      "stormodtagerpostnummer": null,
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "1bd35784-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          10.18800013,
-          56.17230413
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V0"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "\u00c5bogade",
-        "href": "https://dawa.aws.dk/vejstykker/751/9651",
-        "kode": "9651",
-        "navn": "\u00c5bogade"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "\u00c5bogade 15, 1., 8200 Aarhus N",
-    "d\u00f8r": null,
-    "etage": "1",
-    "historik": {
-      "oprettet": "2015-10-05T20:54:34.880",
-      "\u00e6ndret": "2015-10-05T20:54:34.880"
-    },
-    "href": "https://dawa.aws.dk/adresser/606cf42e-9dc2-4477-bf70-594830fcbdec",
-    "id": "606cf42e-9dc2-4477-bf70-594830fcbdec",
-    "kvhx": "07519651__15__1____",
-    "status": 1
-  },
-  "https://dawa.aws.dk/adresser/ae95777c-7ec1-4039-8025-e2ecce5099fb?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6223_574",
-        "km10": "10km_622_57",
-        "m100": "100m_62237_5747"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 14.4,
-        "id": "0a3f5096-c91f-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          10.20320628,
-          56.15263055
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TK",
-        "tekstretning": 217,
-        "\u00e6ndret": "2012-02-20T23:59:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/12337669-a188-6b98-e053-d480220a5a3f",
-          "id": "12337669-a188-6b98-e053-d480220a5a3f",
-          "kode": 11045,
-          "navn": "Aarhus",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2006351,
-        "navn": "\u00c5rhus Bygrunde"
-      },
-      "esrejendomsnr": "397720",
-      "historik": {
-        "oprettet": "2000-02-05T15:27:47.000",
-        "\u00e6ndret": "2012-04-11T17:04:13.630"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f5096-c91f-32b8-e044-0003ba298018",
+      "vejkode": "9651",
+      "vejnavn": "\u00c5bogade",
+      "x": 10.18779751,
+      "y": 56.17233057
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=ae95777c-7ec1-4039-8025-e2ecce5099fb&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f5096-c91f-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "R\u00e5dhuspladsen",
+      "d\u00f8r": null,
+      "etage": "4",
       "husnr": "2",
-      "id": "0a3f5096-c91f-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2006351",
-          "kode": 2006351,
-          "navn": "\u00c5rhus Bygrunde"
-        },
-        "esrejendomsnr": "397720",
-        "href": "https://dawa.aws.dk/jordstykker/2006351/2154",
-        "matrikelnr": "2154"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0751",
-        "kode": "0751",
-        "navn": "Aarhus"
-      },
-      "kvh": "07517005___2",
-      "matrikelnr": "2154",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/65",
-        "kode": "0065",
-        "navn": "Aarhus \u00d8st"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1461",
-        "kode": "1461",
-        "navn": "\u00d8stjyllands Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/8000",
-        "navn": "Aarhus C",
-        "nr": "8000"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1082",
-        "kode": "1082",
-        "navn": "Region Midtjylland"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1165",
-        "kode": "1165",
-        "navn": "Retten i \u00c5rhus"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/8115",
-        "kode": "8115",
-        "navn": "Vor Frue"
-      },
+      "id": "ae95777c-7ec1-4039-8025-e2ecce5099fb",
+      "kommunekode": "0751",
+      "postnr": "8000",
+      "postnrnavn": "Aarhus C",
       "status": 1,
-      "stormodtagerpostnummer": null,
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "1ba84d7a-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          10.20374764,
-          56.15312343
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V2"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "R\u00e5dhuspladsen",
-        "href": "https://dawa.aws.dk/vejstykker/751/7005",
-        "kode": "7005",
-        "navn": "R\u00e5dhuspladsen"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "R\u00e5dhuspladsen 2, 4., 8000 Aarhus C",
-    "d\u00f8r": null,
-    "etage": "4",
-    "historik": {
-      "oprettet": "2015-10-05T19:46:55.817",
-      "\u00e6ndret": "2015-10-05T19:46:55.817"
-    },
-    "href": "https://dawa.aws.dk/adresser/ae95777c-7ec1-4039-8025-e2ecce5099fb",
-    "id": "ae95777c-7ec1-4039-8025-e2ecce5099fb",
-    "kvhx": "07517005___2__4____",
-    "status": 1
-  },
-  "https://dawa.aws.dk/adresser/b1f1817d-5f02-4331-b8b3-97330a5d3197?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6225_574",
-        "km10": "10km_622_57",
-        "m100": "100m_62257_5744"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 49.4,
-        "id": "0a3f5096-a0da-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          10.19938084,
-          56.17102843
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TD",
-        "tekstretning": 375,
-        "\u00e6ndret": "2016-02-16T00:00:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/12337669-a188-6b98-e053-d480220a5a3f",
-          "id": "12337669-a188-6b98-e053-d480220a5a3f",
-          "kode": 11045,
-          "navn": "Aarhus",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2006353,
-        "navn": "\u00c5rhus Markjorder"
-      },
-      "esrejendomsnr": "331045",
-      "historik": {
-        "oprettet": "2000-02-05T15:26:42.000",
-        "\u00e6ndret": "2016-08-25T13:42:00.330"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f5096-a0da-32b8-e044-0003ba298018",
+      "vejkode": "7005",
+      "vejnavn": "R\u00e5dhuspladsen",
+      "x": 10.20320628,
+      "y": 56.15263055
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=b1f1817d-5f02-4331-b8b3-97330a5d3197&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f5096-a0da-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "Nordre Ringgade",
+      "d\u00f8r": null,
+      "etage": null,
       "husnr": "1",
-      "id": "0a3f5096-a0da-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2006353",
-          "kode": 2006353,
-          "navn": "\u00c5rhus Markjorder"
-        },
-        "esrejendomsnr": "331045",
-        "href": "https://dawa.aws.dk/jordstykker/2006353/117gr",
-        "matrikelnr": "117gr"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0751",
-        "kode": "0751",
-        "navn": "Aarhus"
-      },
-      "kvh": "07515902___1",
-      "matrikelnr": "117gr",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/65",
-        "kode": "0065",
-        "navn": "Aarhus \u00d8st"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1461",
-        "kode": "1461",
-        "navn": "\u00d8stjyllands Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/8000",
-        "navn": "Aarhus C",
-        "nr": "8000"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1082",
-        "kode": "1082",
-        "navn": "Region Midtjylland"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1165",
-        "kode": "1165",
-        "navn": "Retten i \u00c5rhus"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/8121",
-        "kode": "8121",
-        "navn": "Christians"
-      },
+      "id": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+      "kommunekode": "0751",
+      "postnr": "8000",
+      "postnrnavn": "Aarhus C",
       "status": 1,
-      "stormodtagerpostnummer": null,
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "1b97bd3c-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          10.19947691,
-          56.1708859
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V2"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "Nordre Ringgade",
-        "href": "https://dawa.aws.dk/vejstykker/751/5902",
-        "kode": "5902",
-        "navn": "Nordre Ringgade"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "Nordre Ringgade 1, 8000 Aarhus C",
-    "d\u00f8r": null,
-    "etage": null,
-    "historik": {
-      "oprettet": "2014-05-05T19:07:48.577",
-      "\u00e6ndret": "2014-05-05T19:07:48.577"
-    },
-    "href": "https://dawa.aws.dk/adresser/b1f1817d-5f02-4331-b8b3-97330a5d3197",
-    "id": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
-    "kvhx": "07515902___1_______",
-    "status": 1
-  },
-  "https://dawa.aws.dk/adresser/bae093df-3b06-4f23-90a8-92eabedb3622?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6175_725",
-        "km10": "10km_617_72",
-        "m100": "100m_61757_7252"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 3.3,
-        "id": "0a3f507a-582d-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          12.58176945,
-          55.67563739
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TD",
-        "tekstretning": 200,
-        "\u00e6ndret": "2002-04-05T00:00:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/290f85b8-8c7a-6fd1-e053-d480220af996",
-          "id": "290f85b8-8c7a-6fd1-e053-d480220af996",
-          "kode": 18368,
-          "navn": "K\u00f8benhavn",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2000169,
-        "navn": "Strand Kvarter, K\u00f8benhavn"
-      },
-      "esrejendomsnr": "509532",
-      "historik": {
-        "oprettet": "2009-11-25T01:07:37.000",
-        "\u00e6ndret": "2009-11-25T01:07:37.000"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f507a-582d-32b8-e044-0003ba298018",
+      "vejkode": "5902",
+      "vejnavn": "Nordre Ringgade",
+      "x": 10.19938084,
+      "y": 56.17102843
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=bae093df-3b06-4f23-90a8-92eabedb3622&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f507a-582d-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "Christiansb Slotspl",
+      "d\u00f8r": null,
+      "etage": null,
       "husnr": "1",
-      "id": "0a3f507a-582d-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2000169",
-          "kode": 2000169,
-          "navn": "Strand Kvarter, K\u00f8benhavn"
-        },
-        "esrejendomsnr": "509532",
-        "href": "https://dawa.aws.dk/jordstykker/2000169/78",
-        "matrikelnr": "78"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0101",
-        "kode": "0101",
-        "navn": "K\u00f8benhavn"
-      },
-      "kvh": "01011128___1",
-      "matrikelnr": "78",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/3",
-        "kode": "0003",
-        "navn": "Indre By"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1470",
-        "kode": "1470",
-        "navn": "K\u00f8benhavns Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/1218",
-        "navn": "K\u00f8benhavn K",
-        "nr": "1218"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1084",
-        "kode": "1084",
-        "navn": "Region Hovedstaden"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1101",
-        "kode": "1101",
-        "navn": "K\u00f8benhavns Byret"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/7036",
-        "kode": "7036",
-        "navn": "Holmens"
-      },
+      "id": "bae093df-3b06-4f23-90a8-92eabedb3622",
+      "kommunekode": "0101",
+      "postnr": "1218",
+      "postnrnavn": "K\u00f8benhavn K",
       "status": 1,
-      "stormodtagerpostnummer": {
-        "href": "https://dawa.aws.dk/postnumre/1240",
-        "navn": "K\u00f8benhavn K",
-        "nr": "1240"
-      },
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "11cde808-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          12.58208068,
-          55.67599723
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V0"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "Christiansb Slotspl",
-        "href": "https://dawa.aws.dk/vejstykker/101/1128",
-        "kode": "1128",
-        "navn": "Christiansborg Slotsplads"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "Christiansborg Slotsplads 1, 1218 K\u00f8benhavn K",
-    "d\u00f8r": null,
-    "etage": null,
-    "historik": {
-      "oprettet": "2014-05-05T19:07:48.577",
-      "\u00e6ndret": "2014-05-05T19:07:48.577"
-    },
-    "href": "https://dawa.aws.dk/adresser/bae093df-3b06-4f23-90a8-92eabedb3622",
-    "id": "bae093df-3b06-4f23-90a8-92eabedb3622",
-    "kvhx": "01011128___1_______",
-    "status": 1
-  },
-  "https://dawa.aws.dk/adresser/d901ff7e-8ad9-4581-84c7-5759aaa82f7b?noformat=1": {
-    "adgangsadresse": {
-      "DDKN": {
-        "km1": "1km_6225_574",
-        "km10": "10km_622_57",
-        "m100": "100m_62257_5745"
-      },
-      "adgangspunkt": {
-        "h\u00f8jde": 48.5,
-        "id": "0a3f5096-a0db-32b8-e044-0003ba298018",
-        "kilde": 5,
-        "koordinater": [
-          10.20019416,
-          56.17063452
-        ],
-        "n\u00f8jagtighed": "A",
-        "tekniskstandard": "TD",
-        "tekstretning": 176,
-        "\u00e6ndret": "2016-08-29T00:00:00.000"
-      },
-      "bebyggelser": [
-        {
-          "href": "https://dawa.aws.dk/bebyggelser/12337669-a188-6b98-e053-d480220a5a3f",
-          "id": "12337669-a188-6b98-e053-d480220a5a3f",
-          "kode": 11045,
-          "navn": "Aarhus",
-          "type": "by"
-        }
-      ],
-      "ejerlav": {
-        "kode": 2006351,
-        "navn": "\u00c5rhus Bygrunde"
-      },
-      "esrejendomsnr": "331045",
-      "historik": {
-        "oprettet": "2000-02-05T15:26:42.000",
-        "\u00e6ndret": "2016-08-29T12:04:14.883"
-      },
-      "href": "https://dawa.aws.dk/adgangsadresser/0a3f5096-a0db-32b8-e044-0003ba298018",
+      "vejkode": "1128",
+      "vejnavn": "Christiansborg Slotsplads",
+      "x": 12.58176945,
+      "y": 55.67563739
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=d901ff7e-8ad9-4581-84c7-5759aaa82f7b&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f5096-a0db-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "Nordre Ringgade",
+      "d\u00f8r": null,
+      "etage": null,
       "husnr": "2",
-      "id": "0a3f5096-a0db-32b8-e044-0003ba298018",
-      "jordstykke": {
-        "ejerlav": {
-          "href": "https://dawa.aws.dk/ejerlav/2006351",
-          "kode": 2006351,
-          "navn": "\u00c5rhus Bygrunde"
-        },
-        "esrejendomsnr": "331045",
-        "href": "https://dawa.aws.dk/jordstykker/2006351/1546o",
-        "matrikelnr": "1546o"
-      },
-      "kommune": {
-        "href": "https://dawa.aws.dk/kommuner/0751",
-        "kode": "0751",
-        "navn": "Aarhus"
-      },
-      "kvh": "07515902___2",
-      "matrikelnr": "1546o",
-      "opstillingskreds": {
-        "href": "https://dawa.aws.dk/opstillingskredse/65",
-        "kode": "0065",
-        "navn": "Aarhus \u00d8st"
-      },
-      "politikreds": {
-        "href": "https://dawa.aws.dk/politikredse/1461",
-        "kode": "1461",
-        "navn": "\u00d8stjyllands Politi"
-      },
-      "postnummer": {
-        "href": "https://dawa.aws.dk/postnumre/8000",
-        "navn": "Aarhus C",
-        "nr": "8000"
-      },
-      "region": {
-        "href": "https://dawa.aws.dk/regioner/1082",
-        "kode": "1082",
-        "navn": "Region Midtjylland"
-      },
-      "retskreds": {
-        "href": "https://dawa.aws.dk/retskredse/1165",
-        "kode": "1165",
-        "navn": "Retten i \u00c5rhus"
-      },
-      "sogn": {
-        "href": "https://dawa.aws.dk/sogne/8120",
-        "kode": "8120",
-        "navn": "Sankt Johannes"
-      },
+      "id": "d901ff7e-8ad9-4581-84c7-5759aaa82f7b",
+      "kommunekode": "0751",
+      "postnr": "8000",
+      "postnrnavn": "Aarhus C",
       "status": 1,
-      "stormodtagerpostnummer": null,
       "supplerendebynavn": null,
-      "vejpunkt": {
-        "id": "1b97bd3d-af45-11e7-847e-066cff24d637",
-        "kilde": "Ekstern",
-        "koordinater": [
-          10.20003555,
-          56.17088567
-        ],
-        "n\u00f8jagtighed": "B",
-        "tekniskstandard": "V2"
-      },
-      "vejstykke": {
-        "adresseringsnavn": "Nordre Ringgade",
-        "href": "https://dawa.aws.dk/vejstykker/751/5902",
-        "kode": "5902",
-        "navn": "Nordre Ringgade"
-      },
-      "zone": "Byzone"
-    },
-    "adressebetegnelse": "Nordre Ringgade 2, 8000 Aarhus C",
-    "d\u00f8r": null,
-    "etage": null,
-    "historik": {
-      "oprettet": "2014-05-05T19:07:48.577",
-      "\u00e6ndret": "2014-05-05T19:07:48.577"
-    },
-    "href": "https://dawa.aws.dk/adresser/d901ff7e-8ad9-4581-84c7-5759aaa82f7b",
-    "id": "d901ff7e-8ad9-4581-84c7-5759aaa82f7b",
-    "kvhx": "07515902___2_______",
-    "status": 1
-  }
+      "vejkode": "5902",
+      "vejnavn": "Nordre Ringgade",
+      "x": 10.20019416,
+      "y": 56.17063452
+    }
+  ]
 }

--- a/backend/tests/mocking/dawa-autocomplete.json
+++ b/backend/tests/mocking/dawa-autocomplete.json
@@ -1,0 +1,165 @@
+{
+  "https://dawa.aws.dk/adresser/autocomplete?per_side=10&noformat=1&kommunekode=751&q=Strandlodsvej+25M": [],
+  "https://dawa.aws.dk/adresser/autocomplete?per_side=10&noformat=1&q=Strandlodsvej+25M": [
+    {
+      "adresse": {
+        "d\u00f8r": "th",
+        "etage": "1",
+        "href": "https://dawa.aws.dk/adresser/b18f681b-dcce-4a1f-9231-08182653dbd9",
+        "husnr": "25M",
+        "id": "b18f681b-dcce-4a1f-9231-08182653dbd9",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 1. th, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "tv",
+        "etage": "1",
+        "href": "https://dawa.aws.dk/adresser/21483493-bf6d-4cdd-badd-74bc5109c7b1",
+        "husnr": "25M",
+        "id": "21483493-bf6d-4cdd-badd-74bc5109c7b1",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 1. tv, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "th",
+        "etage": "2",
+        "href": "https://dawa.aws.dk/adresser/22bf4e3e-14f3-4096-b479-2e8d4ac090fb",
+        "husnr": "25M",
+        "id": "22bf4e3e-14f3-4096-b479-2e8d4ac090fb",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 2. th, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "tv",
+        "etage": "2",
+        "href": "https://dawa.aws.dk/adresser/d4764afd-f5f1-4038-9298-9148bcb56421",
+        "husnr": "25M",
+        "id": "d4764afd-f5f1-4038-9298-9148bcb56421",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 2. tv, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "th",
+        "etage": "3",
+        "href": "https://dawa.aws.dk/adresser/13deac37-805b-4024-a6dc-4b5f6808571c",
+        "husnr": "25M",
+        "id": "13deac37-805b-4024-a6dc-4b5f6808571c",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 3. th, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "tv",
+        "etage": "3",
+        "href": "https://dawa.aws.dk/adresser/2bd96c7d-e9b5-449b-889c-f09a4c1fae50",
+        "husnr": "25M",
+        "id": "2bd96c7d-e9b5-449b-889c-f09a4c1fae50",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 3. tv, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "th",
+        "etage": "4",
+        "href": "https://dawa.aws.dk/adresser/c5871526-6f4f-425c-bd3f-05b837df24cb",
+        "husnr": "25M",
+        "id": "c5871526-6f4f-425c-bd3f-05b837df24cb",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 4. th, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "tv",
+        "etage": "4",
+        "href": "https://dawa.aws.dk/adresser/6ee8b42e-bfc2-42d3-974f-47791c99b375",
+        "husnr": "25M",
+        "id": "6ee8b42e-bfc2-42d3-974f-47791c99b375",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 4. tv, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "th",
+        "etage": "5",
+        "href": "https://dawa.aws.dk/adresser/fd3fceb2-860a-4c15-b57f-795cbfda5882",
+        "husnr": "25M",
+        "id": "fd3fceb2-860a-4c15-b57f-795cbfda5882",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 5. th, 2300 K\u00f8benhavn S"
+    },
+    {
+      "adresse": {
+        "d\u00f8r": "tv",
+        "etage": "5",
+        "href": "https://dawa.aws.dk/adresser/8aa7e68d-e451-43c7-9c02-705ea7a9bb40",
+        "husnr": "25M",
+        "id": "8aa7e68d-e451-43c7-9c02-705ea7a9bb40",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 5. tv, 2300 K\u00f8benhavn S"
+    }
+  ]
+}

--- a/backend/tests/mocking/dawa-autocomplete.json
+++ b/backend/tests/mocking/dawa-autocomplete.json
@@ -1,4 +1,21 @@
 {
+  "https://dawa.aws.dk/adgangsadresser/autocomplete?per_side=5&noformat=1&kommunekode=751&q=Strandlodsvej+25M": [],
+  "https://dawa.aws.dk/adgangsadresser/autocomplete?per_side=5&noformat=1&q=Strandlodsvej+25M": [
+    {
+      "adgangsadresse": {
+        "href": "https://dawa.aws.dk/adgangsadresser/18fbd56e-c6b2-4d0f-bb08-80133edb896e",
+        "husnr": "25M",
+        "id": "18fbd56e-c6b2-4d0f-bb08-80133edb896e",
+        "postnr": "2300",
+        "postnrnavn": "K\u00f8benhavn S",
+        "stormodtagerpostnr": null,
+        "stormodtagerpostnrnavn": null,
+        "supplerendebynavn": null,
+        "vejnavn": "Strandlodsvej"
+      },
+      "tekst": "Strandlodsvej 25M, 2300 K\u00f8benhavn S"
+    }
+  ],
   "https://dawa.aws.dk/adresser/autocomplete?per_side=10&noformat=1&kommunekode=751&q=Strandlodsvej+25M": [],
   "https://dawa.aws.dk/adresser/autocomplete?per_side=10&noformat=1&q=Strandlodsvej+25M": [
     {

--- a/backend/tests/mocking/many-addresses.json
+++ b/backend/tests/mocking/many-addresses.json
@@ -1,0 +1,116 @@
+{
+  "https://dawa.aws.dk/adgangsadresser?id=00000000-0000-0000-0000-000000000000&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/adgangsadresser?id=0a3f507b-6b35-32b8-e044-0003ba298018&noformat=1&struktur=mini": [
+    {
+      "adresseringsvejnavn": "Hold-An Vej",
+      "husnr": "7",
+      "id": "0a3f507b-6b35-32b8-e044-0003ba298018",
+      "kommunekode": "0151",
+      "postnr": "2750",
+      "postnrnavn": "Ballerup",
+      "status": 1,
+      "supplerendebynavn": null,
+      "vejkode": "0152",
+      "vejnavn": "Hold-An Vej",
+      "x": 12.3647784,
+      "y": 55.73404048
+    }
+  ],
+  "https://dawa.aws.dk/adgangsadresser?id=0a3f5081-75bf-32b8-e044-0003ba298018&noformat=1&struktur=mini": [
+    {
+      "adresseringsvejnavn": "Brobjergvej",
+      "husnr": "9",
+      "id": "0a3f5081-75bf-32b8-e044-0003ba298018",
+      "kommunekode": "0350",
+      "postnr": "4060",
+      "postnrnavn": "Kirke S\u00e5by",
+      "status": 1,
+      "supplerendebynavn": "Abbetved",
+      "vejkode": "0086",
+      "vejnavn": "Brobjergvej",
+      "x": 11.91321841,
+      "y": 55.62985492
+    }
+  ],
+  "https://dawa.aws.dk/adgangsadresser?id=bd7e5317-4a9e-437b-8923-11156406b117&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/adresser?id=00000000-0000-0000-0000-000000000000&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/adresser?id=0a3f507b-6b35-32b8-e044-0003ba298018&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/adresser?id=0a3f5081-75bf-32b8-e044-0003ba298018&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/adresser?id=0ead9b4d-c615-442d-8447-b328a73b5b39&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f507a-da84-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "Pilestr\u00e6de",
+      "d\u00f8r": "th",
+      "etage": "3",
+      "husnr": "43",
+      "id": "0ead9b4d-c615-442d-8447-b328a73b5b39",
+      "kommunekode": "0101",
+      "postnr": "1112",
+      "postnrnavn": "K\u00f8benhavn K",
+      "status": 1,
+      "supplerendebynavn": null,
+      "vejkode": "5520",
+      "vejnavn": "Pilestr\u00e6de",
+      "x": 12.57924839,
+      "y": 55.68113676
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=2ef51a73-ad7d-4ee7-e044-0003ba298018&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f507b-6b35-32b8-e044-0003ba298018",
+      "adresseringsvejnavn": "Hold-An Vej",
+      "d\u00f8r": null,
+      "etage": "1",
+      "husnr": "7",
+      "id": "2ef51a73-ad7d-4ee7-e044-0003ba298018",
+      "kommunekode": "0151",
+      "postnr": "2750",
+      "postnrnavn": "Ballerup",
+      "status": 1,
+      "supplerendebynavn": null,
+      "vejkode": "0152",
+      "vejnavn": "Hold-An Vej",
+      "x": 12.3647784,
+      "y": 55.73404048
+    }
+  ],
+  "https://dawa.aws.dk/adresser?id=bd7e5317-4a9e-437b-8923-11156406b117&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/historik/adgangsadresser?id=00000000-0000-0000-0000-000000000000&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/historik/adresser?id=00000000-0000-0000-0000-000000000000&noformat=1&struktur=mini": [],
+  "https://dawa.aws.dk/historik/adresser?id=bd7e5317-4a9e-437b-8923-11156406b117&noformat=1&struktur=mini": [
+    {
+      "adgangsadresseid": "0a3f507b-6b35-32b8-e044-0003ba298018",
+      "adgangspunktstatus": 1,
+      "d\u00f8r": null,
+      "etage": null,
+      "husnr": "7",
+      "id": "bd7e5317-4a9e-437b-8923-11156406b117",
+      "kommunekode": "0151",
+      "postnr": "2750",
+      "postnrnavn": "Ballerup",
+      "status": 1,
+      "supplerendebynavn": null,
+      "vejkode": "0152",
+      "vejnavn": "Hold-An Vej",
+      "virkningslut": "2018-08-08T09:44:38.924Z",
+      "virkningstart": "2016-04-27T12:41:51.207Z"
+    },
+    {
+      "adgangsadresseid": "0a3f507b-6b35-32b8-e044-0003ba298018",
+      "adgangspunktstatus": 1,
+      "d\u00f8r": null,
+      "etage": null,
+      "husnr": "7",
+      "id": "bd7e5317-4a9e-437b-8923-11156406b117",
+      "kommunekode": "0151",
+      "postnr": "2750",
+      "postnrnavn": "Ballerup",
+      "status": 2,
+      "supplerendebynavn": null,
+      "vejkode": "0152",
+      "vejnavn": "Hold-An Vej",
+      "virkningslut": null,
+      "virkningstart": "2018-08-08T09:44:38.924Z"
+    }
+  ]
+}

--- a/backend/tests/mocking/update-fixture.py
+++ b/backend/tests/mocking/update-fixture.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+'''
+Update, i.e. re-fetch, a JSON fixture
+'''
+
+import operator
+import os
+import json
+import sys
+
+import requests
+
+
+def update(p):
+    sess = requests.Session()
+
+    with open(p) as fp:
+        d = json.load(fp)
+
+    def get(url):
+        print(url, file=sys.stderr)
+        r = sess.get(url)
+        r.raise_for_status()
+
+        return r.json()
+
+    with open(p + '~', 'w') as fp:
+        json.dump(
+            dict(zip(d, map(get, d))),
+            fp,
+            indent=2,
+            sort_keys=True,
+        )
+
+        # ensure trailing newline
+        fp.write('\n')
+
+    os.rename(fp.name, p)
+
+
+if __name__ == '__main__':
+    for arg in sys.argv[1:]:
+        update(arg)

--- a/backend/tests/test_integration_address.py
+++ b/backend/tests/test_integration_address.py
@@ -8,6 +8,7 @@
 
 import copy
 import logging
+import re
 import unittest.mock
 
 import freezegun
@@ -2792,8 +2793,61 @@ class Reading(util.LoRATestCase):
         unitid = "04c78fc2-72d2-4d02-b55f-807af19eac48"
         addrid = "bd7e5317-4a9e-437b-8923-11156406b117"
 
+        for t in ('adresser', 'adgangsadresser',
+                  'historik/adresser', 'historik/adgangsadresser'):
+            mock.get(
+                'https://dawa.aws.dk/' + t,
+                json=[],
+            )
+
+        lora.Connector().organisationenhed.update(
+            {
+                'relationer': {
+                    'adresser': [
+                        {
+                            'objekttype': address_class['uuid'],
+                            'uuid': addrid,
+                            'virkning': {
+                                'from': '2016-01-01',
+                                'to': '2020-01-01',
+                            },
+                        },
+                    ],
+                },
+            },
+            unitid,
+        )
+
+        self.assertRequestResponse(
+            '/service/ou/{}/details/address'.format(unitid),
+            [{
+                'name': 'Ukendt',
+                'error': 'Ukendt',
+                'address_type': address_class,
+                'href': None,
+                'org_unit': {
+                    'name': 'Afdeling for Samtidshistorik',
+                    'user_key': 'frem',
+                    'uuid': unitid,
+                    'validity': {
+                        'from': '2016-01-01', 'to': '2018-12-31',
+                    },
+                },
+                'uuid': addrid,
+                'validity': {
+                    'from': '2016-01-01', 'to': '2019-12-31',
+                },
+            }],
+        )
+
+    def test_missing_error(self, mock):
+        self.load_sample_structures()
+
+        unitid = "04c78fc2-72d2-4d02-b55f-807af19eac48"
+        addrid = "bd7e5317-4a9e-437b-8923-11156406b117"
+
         mock.get(
-            'https://dawa.aws.dk/adresser/{}?noformat=1'.format(addrid),
+            'https://dawa.aws.dk/adresser',
             json={
                 "type": "ResourceNotFoundError",
                 "title": "The resource was not found",
@@ -2801,7 +2855,7 @@ class Reading(util.LoRATestCase):
                     "id": "bd7e5317-4a9e-437b-8923-11156406b117",
                 },
             },
-            status_code=404,
+            status_code=500,
         )
 
         lora.Connector().organisationenhed.update(
@@ -2878,14 +2932,16 @@ class Reading(util.LoRATestCase):
             unitid,
         )
 
+        mock_error_msg = ('No mock address: GET '
+                          'https://dawa.aws.dk/adresser?id={}'
+                          '&noformat=1&struktur=mini').format(addrid)
+
         with self.assertLogs(self.app.logger, logging.WARNING) as log_res:
             self.assertRequestResponse(
                 '/service/ou/{}/details/address'.format(unitid),
                 [{
                     'name': 'Fejl',
-                    'error': 'No mock address: GET '
-                    'https://dawa.aws.dk/adresser/{}?noformat=1'
-                    .format(addrid),
+                    'error': mock_error_msg,
                     'address_type': address_class,
                     'href': None,
                     'org_unit': {
@@ -2904,5 +2960,5 @@ class Reading(util.LoRATestCase):
             )
 
             self.assertRegex(log_res.output[0],
-                             "AN ERROR OCCURRED in '[^']*': "
-                             "failed to get address")
+                             "ADDRESS LOOKUP FAILED in '[^']*':\n" +
+                             re.escape(mock_error_msg))

--- a/backend/tests/test_integration_manager.py
+++ b/backend/tests/test_integration_manager.py
@@ -2570,7 +2570,8 @@ class Tests(util.LoRATestCase):
                     'name': 'Fejl',
                     'error': 'No mock address: '
                     'GET https://dawa.aws.dk/adresser'
-                    '/44c532e1-f617-4174-b144-d37ce9fda2bd?noformat=1',
+                    '?id=44c532e1-f617-4174-b144-d37ce9fda2bd'
+                    '&noformat=1&struktur=mini',
                     'uuid': '44c532e1-f617-4174-b144-d37ce9fda2bd',
                     'address_type': {
                         'example': '<UUID>',

--- a/backend/tests/test_service_address.py
+++ b/backend/tests/test_service_address.py
@@ -115,167 +115,98 @@ class TestAddressLookup(util.TestCase):
             status_code=400,
         )
 
-    @util.mock()
-    @freezegun.freeze_time('2016-06-06')
+    @freezegun.freeze_time('2017-07-28')
+    @util.mock(('reading-organisation.json', 'dawa-autocomplete.json'))
     def test_autocomplete(self, mock):
-        mock.get(
-            'http://mox/organisation/organisation'
-            '?uuid=456362c4-0ee4-4e5e-a72c-751239745e62'
-            '&virkningfra=2016-06-06T00%3A00%3A00%2B02%3A00'
-            '&virkningtil=2016-06-06T00%3A00%3A00.000001%2B02%3A00',
-            json={
-                "results": [
-                    [{
-                        "id": "00000000-0000-0000-0000-000000000000",
-                        "registreringer": [
-                            {
-                                "attributter": {
-                                    "organisationegenskaber": [
-                                        {
-                                            "brugervendtnoegle": "bvn",
-                                            "organisationsnavn": "onavn",
-                                        }
-                                    ]
-                                },
-                                "relationer": {
-                                    "myndighed": [
-                                        {
-                                            "urn": "urn:dk:kommune:751",
-                                        }
-                                    ]
-                                },
-                                "tilstande": {
-                                    "organisationgyldighed": [
-                                        {
-                                            "gyldighed": "Aktiv",
-                                        }
-                                    ]
-                                },
-                            }
-                        ]
-                    }]
-                ]
+        found = [
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 1. th, 2300 K\u00f8benhavn S",
+                    "uuid": "b18f681b-dcce-4a1f-9231-08182653dbd9"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 1. tv, 2300 K\u00f8benhavn S",
+                    "uuid": "21483493-bf6d-4cdd-badd-74bc5109c7b1"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 2. th, 2300 K\u00f8benhavn S",
+                    "uuid": "22bf4e3e-14f3-4096-b479-2e8d4ac090fb"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 2. tv, 2300 K\u00f8benhavn S",
+                    "uuid": "d4764afd-f5f1-4038-9298-9148bcb56421"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 3. th, 2300 K\u00f8benhavn S",
+                    "uuid": "13deac37-805b-4024-a6dc-4b5f6808571c"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 3. tv, 2300 K\u00f8benhavn S",
+                    "uuid": "2bd96c7d-e9b5-449b-889c-f09a4c1fae50"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 4. th, 2300 K\u00f8benhavn S",
+                    "uuid": "c5871526-6f4f-425c-bd3f-05b837df24cb"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 4. tv, 2300 K\u00f8benhavn S",
+                    "uuid": "6ee8b42e-bfc2-42d3-974f-47791c99b375"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 5. th, 2300 K\u00f8benhavn S",
+                    "uuid": "fd3fceb2-860a-4c15-b57f-795cbfda5882"
+                }
+            },
+            {
+                "location": {
+                    "name": "Strandlodsvej 25M, 5. tv, 2300 K\u00f8benhavn S",
+                    "uuid": "8aa7e68d-e451-43c7-9c02-705ea7a9bb40"
+                }
             }
+        ]
+
+        self.assertRequestResponse(
+            '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
+            'address_autocomplete/?q=Strandlodsvej+25M&global=1',
+            found,
         )
 
-        mock.get(
-            'https://dawa.aws.dk/adresser/autocomplete?'
-            'kommunekode=751&noformat=1&q=42',
-            json=[{
-                "tekst": "Strandlodsvej 25M, 7. tv, 2300 København S",
-                "adresse": {
-                    "id": "00002732-733c-433a-a5da-a7d428a980cf",
-                    "href": "https://dawa.aws.dk/adresser/"
-                            "00002732-733c-433a-a5da-a7d428a980cf",
-                    "vejnavn": "Strandlodsvej",
-                    "husnr": "25M",
-                    "etage": "7",
-                    "dør": "tv",
-                    "supplerendebynavn": None,
-                    "postnr": "2300",
-                    "postnrnavn": "København S",
-                    "stormodtagerpostnr": None,
-                    "stormodtagerpostnrnavn": None
-                }
-            }])
+        self.assertRequestResponse(
+            '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
+            'address_autocomplete/?q=Strandlodsvej+25M&global=true',
+            found,
+        )
 
         self.assertRequestResponse(
             '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
-            'address_autocomplete/?q=42',
-            [{
-                'location': {
-                    'uuid': "00002732-733c-433a-a5da-a7d428a980cf",
-                    'name': 'Strandlodsvej 25M, 7. tv, 2300 København S'
-                }
-            }])
-
-    @freezegun.freeze_time('2017-07-28')
-    @util.mock('reading-organisation.json')
-    def test_autocomplete_global(self, mock):
-        mock.get(
-            'https://dawa.aws.dk/adresser/autocomplete?noformat=1&q=42',
-            json=[{
-                "tekst": "Strandlodsvej 25M, 7. tv, 2300 København S",
-                "adresse": {
-                    "id": "00002732-733c-433a-a5da-a7d428a980cf",
-                    "href": "https://dawa.aws.dk/adresser/"
-                            "00002732-733c-433a-a5da-a7d428a980cf",
-                    "vejnavn": "Strandlodsvej",
-                    "husnr": "25M",
-                    "etage": "7",
-                    "dør": "tv",
-                    "supplerendebynavn": None,
-                    "postnr": "2300",
-                    "postnrnavn": "København S",
-                    "stormodtagerpostnr": None,
-                    "stormodtagerpostnrnavn": None
-                }
-            }])
-        mock.get(
-            'https://dawa.aws.dk/adresser/autocomplete'
-            '?noformat=1&q=42&kommunekode=751',
-            json=[{
-                "tekst": "Hestfestegade 42, 8000 Aarhus C",
-                "adresse": {
-                    "id": "00000000-0000-0000-0000-000000000000",
-                    "href": "https://dawa.aws.dk/adresser/"
-                            "00000000-0000-0000-0000-000000000000",
-                    "vejnavn": "Hestfestegade",
-                    "husnr": "42",
-                    "supplerendebynavn": None,
-                    "postnr": "8000",
-                    "postnrnavn": "Aarhus C",
-                    "stormodtagerpostnr": None,
-                    "stormodtagerpostnrnavn": None
-                }
-            }])
+            'address_autocomplete/?q=Strandlodsvej+25M',
+            [],
+        )
 
         self.assertRequestResponse(
             '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
-            'address_autocomplete/?q=42&global=1',
-            [{
-                'location': {
-                    'uuid': "00002732-733c-433a-a5da-a7d428a980cf",
-                    'name': 'Strandlodsvej 25M, 7. tv, 2300 København S'
-                }
-            }])
+            'address_autocomplete/?q=Strandlodsvej+25M&global=0',
+            [],
+        )
 
         self.assertRequestResponse(
             '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
-            'address_autocomplete/?q=42&global=true',
-            [{
-                'location': {
-                    'uuid': "00002732-733c-433a-a5da-a7d428a980cf",
-                    'name': 'Strandlodsvej 25M, 7. tv, 2300 København S'
-                }
-            }])
-
-        self.assertRequestResponse(
-            '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
-            'address_autocomplete/?q=42',
-            [{
-                'location': {
-                    'uuid': "00000000-0000-0000-0000-000000000000",
-                    'name': 'Hestfestegade 42, 8000 Aarhus C'
-                }
-            }])
-
-        self.assertRequestResponse(
-            '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
-            'address_autocomplete/?q=42&global=0',
-            [{
-                'location': {
-                    'uuid': "00000000-0000-0000-0000-000000000000",
-                    'name': 'Hestfestegade 42, 8000 Aarhus C'
-                }
-            }])
-
-        self.assertRequestResponse(
-            '/service/o/456362c4-0ee4-4e5e-a72c-751239745e62/'
-            'address_autocomplete/?q=42&global=false',
-            [{
-                'location': {
-                    'uuid': "00000000-0000-0000-0000-000000000000",
-                    'name': 'Hestfestegade 42, 8000 Aarhus C'
-                }
-            }])
+            'address_autocomplete/?q=Strandlodsvej+25M&global=false',
+            [],
+        )

--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -276,20 +276,24 @@ class mock(requests_mock.Mocker):
 
     '''
 
-    def __init__(self, name=None, allow_mox=False, **kwargs):
+    def __init__(self, names=None, allow_mox=False, **kwargs):
         super().__init__(**kwargs)
 
-        self.__name = name
+        self.__names = names
         self.__allow_mox = allow_mox
         self.__kwargs = kwargs
 
-        if name:
+        if names:
+            if not isinstance(names, (list, tuple)):
+                names = [names]
+
             # inject the fixture; note that complete_qs is
             # important: without it, a URL need only match *some*
             # of the query parameters passed, and that's quite
             # obnoxious if requests only differ by them
-            for url, value in get_mock_data(name).items():
-                self.get(url, json=value, complete_qs=True)
+            for name in names:
+                for url, value in get_mock_data(name).items():
+                    self.get(url, json=value, complete_qs=True)
 
         if not allow_mox:
             self.__overrider = override_lora_url()
@@ -304,7 +308,7 @@ class mock(requests_mock.Mocker):
     def copy(self):
         """Returns an exact copy of current mock
         """
-        return mock(self.__name, self.__allow_mox, **self.__kwargs)
+        return mock(self.__names, self.__allow_mox, **self.__kwargs)
 
     def start(self):
         if self.__overrider:


### PR DESCRIPTION
<!-- Insert a link for relevant Redmine ticket(s) here -->
https://redmine.magenta-aps.dk/issues/24077

This change adds support for DAWA access addresses — _adgangsadresser_ — to autocomplete and rendering. It also adds a fallback to historic entries, although they differ slightly from current addresses as they may omit the coordinates; in this case, we omit the OSM link.

- [x] Have you updated the documentation?
- [x] Have you performed a smoke test of the application?
- [x] Have you written tests for your changes?
- [x] Have you updated the release notes?

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->