### PR TITLE
Prevent edits in the past.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,14 @@
 Version 0.14.0, in development
 =============================
 
+New features
+------------
+
+* #25405: Submit button for create new and edit modals for organisation 
+  units and employees is no longer disabled if the form is invalid
+* #25394: It is now no longer possible to perform edits taking effect before
+  the current date.
+
 Internal changes
 ----------------
 

--- a/backend/mora/exceptions.py
+++ b/backend/mora/exceptions.py
@@ -76,6 +76,8 @@ class ErrorCodes(Enum):
         404, "Corresponding parent unit or organisation not found."
     V_DUPLICATED_RESPONSIBILITY = \
         400, "Manager has the same responsibility more than once."
+    V_CHANGING_THE_PAST = \
+        400, "Cannot perform changes before current date"
 
     # Input errors
     E_ORG_UNIT_NOT_FOUND = 404, "Org unit not found."

--- a/backend/mora/lora.py
+++ b/backend/mora/lora.py
@@ -283,7 +283,7 @@ class Connector:
         if self.validity == 'present':
             return util.do_ranges_overlap(self.start, self.end, start, end)
         else:
-            return start >= self.start and end <= self.end
+            return start > self.start and end <= self.end
 
     def get_date_chunks(self, dates):
         a, b = itertools.tee(sorted(dates))

--- a/backend/mora/service/association.py
+++ b/backend/mora/service/association.py
@@ -94,6 +94,8 @@ class AssociationRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
+        validator.is_edit_from_date_before_today(new_from)
+
         payload = dict()
         payload['note'] = 'Rediger tilknytning'
 

--- a/backend/mora/service/employee.py
+++ b/backend/mora/service/employee.py
@@ -30,6 +30,7 @@ from .. import lora
 from .. import mapping
 from .. import settings
 from .. import util
+from .. import validator
 
 blueprint = flask.Blueprint('employee', __name__, static_url_path='',
                             url_prefix='/service')
@@ -97,6 +98,8 @@ class EmployeeRequestHandler(handlers.RequestHandler):
         c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
         original = c.bruger.get(uuid=userid)
         new_from, new_to = util.get_validities(data)
+
+        validator.is_edit_from_date_before_today(new_from)
 
         payload = dict()
         if original_data:

--- a/backend/mora/service/engagement.py
+++ b/backend/mora/service/engagement.py
@@ -91,6 +91,8 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
+        validator.is_edit_from_date_before_today(new_from)
+
         payload = dict()
         payload['note'] = 'Rediger engagement'
 

--- a/backend/mora/service/handlers.py
+++ b/backend/mora/service/handlers.py
@@ -21,6 +21,7 @@ from .. import exceptions
 from .. import lora
 from .. import mapping
 from .. import util
+from .. import validator
 
 
 @enum.unique
@@ -195,6 +196,8 @@ class OrgFunkRequestHandler(RequestHandler):
         original = request['original']
 
         validity = mapping.ORG_FUNK_GYLDIGHED_FIELD(original)
+
+        validator.is_edit_from_date_before_today(date)
 
         self.payload = common.update_payload(
             max(date, util.get_effect_from(validity[0])),

--- a/backend/mora/service/itsystem.py
+++ b/backend/mora/service/itsystem.py
@@ -99,6 +99,8 @@ class ItsystemRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
+        validator.is_edit_from_date_before_today(new_from)
+
         payload = {
             'note': 'Rediger IT-system',
         }

--- a/backend/mora/service/leave.py
+++ b/backend/mora/service/leave.py
@@ -76,6 +76,8 @@ class LeaveRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
+        validator.is_edit_from_date_before_today(new_from)
+
         payload = dict()
         payload['note'] = 'Rediger orlov'
 

--- a/backend/mora/service/manager.py
+++ b/backend/mora/service/manager.py
@@ -108,6 +108,8 @@ class ManagerRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
+        validator.is_edit_from_date_before_today(new_from)
+
         # Get org unit uuid for validation purposes
         org_unit_uuid = util.get_obj_uuid(
             original, mapping.ASSOCIATED_ORG_UNIT_FIELD.path)

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -175,6 +175,8 @@ class OrgUnitRequestHandler(handlers.ReadingRequestHandler):
 
         new_from, new_to = util.get_validities(data)
 
+        validator.is_edit_from_date_before_today(new_from)
+
         # Get org unit uuid for validation purposes
         parent = util.get_obj_value(
             original, mapping.PARENT_FIELD.path)[-1]

--- a/backend/mora/service/role.py
+++ b/backend/mora/service/role.py
@@ -80,6 +80,8 @@ class RoleRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
+        validator.is_edit_from_date_before_today(new_from)
+
         payload = dict()
         payload['note'] = 'Rediger rolle'
 

--- a/backend/mora/util.py
+++ b/backend/mora/util.py
@@ -724,7 +724,8 @@ tzinfo=tzfile('/usr/share/zoneinfo/Europe/Copenhagen'))
         return POSITIVE_INFINITY
 
 
-def get_validities(obj, fallback=None):
+def get_validities(obj, fallback=None) -> typing.Tuple[
+        datetime.datetime, datetime.datetime]:
     valid_from = get_valid_from(obj, fallback)
     valid_to = get_valid_to(obj, fallback)
     if valid_to < valid_from:

--- a/backend/mora/validator.py
+++ b/backend/mora/validator.py
@@ -312,3 +312,15 @@ def does_employee_have_active_engagement(employee_uuid, valid_from, valid_to):
 
     if not valid_effects:
         exceptions.ErrorCodes.V_NO_ACTIVE_ENGAGEMENT(employee=employee_uuid)
+
+
+def is_edit_from_date_before_today(from_date: datetime.datetime):
+    """Check if a given edit date is before today. If so, raise exception"""
+    today = datetime.datetime.combine(
+        datetime.date.today(),
+        datetime.time(0, 0, 0, 0, from_date.tzinfo)
+    )
+    if from_date < today:
+        raise exceptions.ErrorCodes.V_CHANGING_THE_PAST(
+            date=util.to_iso_time(from_date)
+        )

--- a/backend/tests/test_integration_association.py
+++ b/backend/tests/test_integration_association.py
@@ -2159,6 +2159,39 @@ class Tests(util.LoRATestCase):
             expected,
         )
 
+    def test_edit_association_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        association_uuid = 'c2153d5d-4a2b-492d-a18c-c498f7bb6221'
+
+        req = [{
+            "type": "association",
+            "uuid": association_uuid,
+            "data": {
+                "job_function": {
+                    'uuid': "cac9c6a8-b432-4e50-b33e-e96f742d4d56"},
+                "association_type": {
+                    'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
+                },
+                "validity": {
+                    "from": "2000-01-01",
+                },
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2000-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)
+
     def test_terminate_association(self):
         self.load_sample_structures()
 

--- a/backend/tests/test_integration_employee.py
+++ b/backend/tests/test_integration_employee.py
@@ -679,3 +679,34 @@ class Tests(util.LoRATestCase):
             expected_tilknyttedepersoner,
             actual['relationer']['tilknyttedepersoner']
         )
+
+    def test_edit_employee_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        userid = "6ee24785-ee9a-4502-81c2-7697009c9053"
+
+        req = [{
+            "type": "employee",
+            "original": None,
+            "data": {
+                "validity": {
+                    "from": "2000-01-01",
+                },
+                "cpr_no": "0101010101",
+                "name": "Test 1 Employee",
+            },
+            "uuid": userid
+        }]
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2000-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)

--- a/backend/tests/test_integration_engagement.py
+++ b/backend/tests/test_integration_engagement.py
@@ -1376,6 +1376,35 @@ class Tests(util.LoRATestCase):
 
         self.assertRegistrationsEqual(expected_engagement, actual_engagement)
 
+    def test_edit_engagement_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        engagement_uuid = 'd000591f-8705-4324-897a-075e3623f37b'
+
+        req = [{
+            "type": "engagement",
+            "uuid": engagement_uuid,
+            "data": {
+                "org_unit": {'uuid': "b688513d-11f7-4efc-b679-ab082a2055d0"},
+                "validity": {
+                    "from": "2000-01-01",
+                }
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2000-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)
+
     def test_terminate_engagement(self):
         self.load_sample_structures()
 

--- a/backend/tests/test_integration_itsystem.py
+++ b/backend/tests/test_integration_itsystem.py
@@ -417,7 +417,7 @@ class Writing(util.LoRATestCase):
                             "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                         },
                         "validity": {
-                            "from": "2017-06-01",
+                            "from": "2018-01-01",
                             "to": "2018-06-01",
                         }
                     }
@@ -436,7 +436,7 @@ class Writing(util.LoRATestCase):
                 'validity': {'from': '2010-01-01', 'to': None},
             },
             validity={
-                "from": "2017-06-01",
+                "from": "2018-01-01",
                 "to": "2018-06-01",
             },
         )
@@ -599,7 +599,7 @@ class Writing(util.LoRATestCase):
                             "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                         },
                         "validity": {
-                            "from": "2017-06-01",
+                            "from": "2017-06-22",
                             "to": "2018-06-01",
                         }
                     }
@@ -618,12 +618,12 @@ class Writing(util.LoRATestCase):
                 'validity': {'from': '2010-01-01', 'to': None},
             },
             validity={
-                "from": "2017-06-01",
+                "from": "2017-06-22",
                 "to": "2018-06-01",
             },
         )
 
-        original['validity']['to'] = '2017-05-31'
+        original['validity']['to'] = '2017-06-21'
         original['org_unit']['name'] = 'Afdeling for Fremtidshistorik'
 
         self.assertRequestResponse(
@@ -640,6 +640,37 @@ class Writing(util.LoRATestCase):
             '/service/ou/{}/details/it?validity=future'.format(unitid),
             [],
         )
+
+    def test_edit_itsystem_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        function_id = "cd4dcccb-5bf7-4c6b-9e1a-f6ebb193e276"
+
+        req = {
+            "type": "it",
+            "uuid": function_id,
+            "data": {
+                "itsystem": {
+                    "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
+                },
+                "validity": {
+                    "from": "2000-01-01",
+                }
+            }
+        }
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2000-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)
 
     @freezegun.freeze_time('2017-06-22', tz_offset=2)
     def test_edit_move_itsystem(self):
@@ -698,7 +729,7 @@ class Writing(util.LoRATestCase):
                         },
                         "user_key": "wooble",
                         "validity": {
-                            "from": "2017-06-01",
+                            "from": "2017-06-22",
                             "to": "2018-06-01",
                         },
                     },
@@ -720,7 +751,7 @@ class Writing(util.LoRATestCase):
                 'uuid': new_userid,
             },
             validity={
-                "from": "2017-06-01",
+                "from": "2017-06-22",
                 "to": "2018-06-01",
             },
         )

--- a/backend/tests/test_integration_leave.py
+++ b/backend/tests/test_integration_leave.py
@@ -16,7 +16,7 @@ from tests import util
 mock_uuid = '1eb680cd-d8ec-4fd2-8ca0-dce2d03f59a5'
 
 
-@freezegun.freeze_time('2017-01-01', tz_offset=1)
+@freezegun.freeze_time('2016-01-01', tz_offset=1)
 @patch('uuid.uuid4', new=lambda: mock_uuid)
 class Tests(util.LoRATestCase):
     maxDiff = None
@@ -644,8 +644,6 @@ class Tests(util.LoRATestCase):
     def test_edit_leave_fails_when_no_active_engagement(self):
         self.load_sample_structures()
 
-        userid = "53181ed2-f1de-4c4a-a8fd-ab358c2c454a"
-
         leave_uuid = 'b807628c-030c-4f5f-a438-de41c1f26ba5'
 
         req = [{
@@ -656,8 +654,8 @@ class Tests(util.LoRATestCase):
                     'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
                 },
                 "validity": {
-                    "from": "2000-04-01",
-                    "to": "2000-04-01",
+                    "from": "2016-04-01",
+                    "to": "2016-04-01",
                 },
             },
         }]

--- a/backend/tests/test_integration_leave.py
+++ b/backend/tests/test_integration_leave.py
@@ -673,6 +673,38 @@ class Tests(util.LoRATestCase):
             status_code=400
         )
 
+    @freezegun.freeze_time('2020-01-01')
+    def test_edit_leave_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        leave_uuid = 'b807628c-030c-4f5f-a438-de41c1f26ba5'
+
+        req = [{
+            "type": "leave",
+            "uuid": leave_uuid,
+            "data": {
+                "leave_type": {
+                    'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
+                },
+                "validity": {
+                    "from": "2018-01-01",
+                },
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2018-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)
+
     def test_terminate_leave(self):
         self.load_sample_structures()
 

--- a/backend/tests/test_integration_manager.py
+++ b/backend/tests/test_integration_manager.py
@@ -2385,6 +2385,37 @@ class Tests(util.LoRATestCase):
             [],
         )
 
+    def test_edit_manager_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        manager_uuid = '05609702-977f-4869-9fb4-50ad74c6999a'
+
+        req = {
+            "type": "manager",
+            "uuid": manager_uuid,
+            "data": {
+                "manager_type": {
+                    'uuid': "ca76a441-6226-404f-88a9-31e02e420e52"
+                },
+                "validity": {
+                    "from": "2000-01-01",
+                },
+            },
+        }
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2000-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)
+
     def test_read_manager_multiple_responsibilities(self):
         '''Test reading a manager with multiple responsibilities, all valid'''
         self.load_sample_structures()

--- a/backend/tests/test_integration_manager.py
+++ b/backend/tests/test_integration_manager.py
@@ -2322,11 +2322,11 @@ class Tests(util.LoRATestCase):
                 "type": "manager",
                 "uuid": manager_uuid,
                 "data": {
-                    "responsibility": [{
+                    "manager_type": {
                         'uuid': "ca76a441-6226-404f-88a9-31e02e420e52"
-                    }],
+                    },
                     "validity": {
-                        "from": "2016-04-01",
+                        "from": "2017-01-01",
                     },
                 },
             },
@@ -2336,8 +2336,8 @@ class Tests(util.LoRATestCase):
         expected_changed_lora = copy.deepcopy(expected_lora)
         expected_changed_lora['note'] = 'Rediger leder'
         expected_changed_lora['livscykluskode'] = 'Rettet'
-        expected_changed_lora['relationer']['opgaver'][0]['uuid'] = \
-            "ca76a441-6226-404f-88a9-31e02e420e52"
+        expected_changed_lora['relationer']['organisatoriskfunktionstype'][0][
+            'uuid'] = "ca76a441-6226-404f-88a9-31e02e420e52"
 
         for g, f in (
                 ('attributter', 'organisationfunktionegenskaber'),
@@ -2350,16 +2350,16 @@ class Tests(util.LoRATestCase):
                 ('tilstande', 'organisationfunktiongyldighed'),
         ):
             for m in expected_changed_lora[g][f]:
-                m['virkning']['from'] = '2016-04-01 00:00:00+02'
+                m['virkning']['from'] = '2017-01-01 00:00:00+01'
 
-        expected_mora[0]['validity']['from'] = '2016-04-01'
-        expected_mora[0]['responsibility'] = [{
+        expected_mora[0]['validity']['from'] = '2017-01-01'
+        expected_mora[0]['manager_type'] = {
             'example': None,
             'name': 'Institut',
             'scope': None,
             'user_key': 'inst',
             'uuid': 'ca76a441-6226-404f-88a9-31e02e420e52',
-        }]
+        }
 
         # compare them!
         actual_lora = c.organisationfunktion.get(manager_uuid)

--- a/backend/tests/test_integration_org_unit.py
+++ b/backend/tests/test_integration_org_unit.py
@@ -1327,6 +1327,37 @@ class Tests(util.LoRATestCase):
 
         self.assertRegistrationsEqual(expected, actual)
 
+    def test_edit_org_unit_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        org_unit_uuid = '85715fc7-925d-401b-822d-467eb4b163b6'
+
+        req = [{
+            "type": "org_unit",
+            "data": {
+                "uuid": org_unit_uuid,
+                "org_unit_type": {
+                    'uuid': "79e15798-7d6d-4e85-8496-dcc8887a1c1a"
+                },
+                "validity": {
+                    "from": "2000-01-01",
+                },
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2000-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)
+
     def test_create_missing_parent(self):
         self.load_sample_structures()
 

--- a/backend/tests/test_integration_org_unit.py
+++ b/backend/tests/test_integration_org_unit.py
@@ -996,6 +996,7 @@ class Tests(util.LoRATestCase):
 
         self.assertRegistrationsEqual(expected, actual)
 
+    @freezegun.freeze_time('2010-01-01')
     def test_edit_org_unit_earlier_start(self):
         '''Test setting the start date to something earlier (#23182)'''
 
@@ -1169,6 +1170,7 @@ class Tests(util.LoRATestCase):
 
         self.assertRegistrationsEqual(expected, actual)
 
+    @freezegun.freeze_time('2016-01-01')
     @util.mock('aabogade.json', allow_mox=True)
     def test_edit_org_unit_earlier_start_on_created(self, m):
         self.load_sample_structures()
@@ -1570,6 +1572,7 @@ class Tests(util.LoRATestCase):
 
         self.assertRegistrationsEqual(expected, actual)
 
+    @freezegun.freeze_time('2016-01-01')
     def test_rename_org_unit_early(self):
         # Test that we can rename a unit to a date *earlier* than its
         # creation date. We are expanding the validity times on the
@@ -1983,6 +1986,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json=req)
 
+    @freezegun.freeze_time('2010-01-01')
     def test_cannot_extend_beyond_parent(self):
         """Should fail validation since the new validity period extends beyond
         that of the parent. (#23155)"""

--- a/backend/tests/test_integration_role.py
+++ b/backend/tests/test_integration_role.py
@@ -855,6 +855,34 @@ class Tests(util.LoRATestCase):
 
         self.assertRegistrationsEqual(expected_role, actual_role)
 
+    def test_edit_role_in_the_past_fails(self):
+        """It shouldn't be possible to perform an edit in the past"""
+        self.load_sample_structures()
+
+        role_uuid = '1b20d0b9-96a0-42a6-b196-293bb86e62e8'
+
+        req = [{
+            "type": "role",
+            "uuid": role_uuid,
+            "data": {
+                "validity": {
+                    "from": "2000-01-01",
+                },
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/details/edit',
+            {
+                'description': 'Cannot perform changes before current date',
+                'error': True,
+                'error_key': 'V_CHANGING_THE_PAST',
+                'date': '2000-01-01T00:00:00+01:00',
+                'status': 400
+            },
+            json=req,
+            status_code=400)
+
     def test_terminate_role(self):
         self.load_sample_structures()
 

--- a/backend/tests/test_integration_validator.py
+++ b/backend/tests/test_integration_validator.py
@@ -348,5 +348,3 @@ class TestIsContainedInEmployeeRange(TestHelper):
         # Should not raise an exception
         validator.is_contained_in_employee_range(empl_from, empl_to,
                                                  valid_from, valid_to)
-
-

--- a/backend/tests/test_integration_validator.py
+++ b/backend/tests/test_integration_validator.py
@@ -348,3 +348,5 @@ class TestIsContainedInEmployeeRange(TestHelper):
         # Should not raise an exception
         validator.is_contained_in_employee_range(empl_from, empl_to,
                                                  valid_from, valid_to)
+
+

--- a/backend/tests/test_validator.py
+++ b/backend/tests/test_validator.py
@@ -12,7 +12,7 @@ import unittest
 import freezegun
 import requests_mock
 
-from mora import lora
+from mora import lora, exceptions
 from mora import settings
 from mora import validator
 from mora import util as mora_util
@@ -182,3 +182,37 @@ class TestGetEndpointDate(unittest.TestCase):
         self.startdate = datetime.datetime(
             2017, 1, 1, 0, 0, 0,
             tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
+
+
+@freezegun.freeze_time("2017-01-01")
+class TestIsEditDateBeforeToday(util.TestCase):
+
+    def test_past_dates_raises_exception(self):
+        """Assert that using a date before today raises an exception"""
+
+        test_date = datetime.datetime(
+            2016, 12, 31, 0, 0, 0,
+            tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
+
+        with self.assertRaises(exceptions.HTTPException):
+            validator.is_edit_from_date_before_today(test_date)
+
+    def test_today_does_not_raise_exception(self):
+        """Assert that today's date does not raise an exception"""
+
+        test_date = datetime.datetime(
+            2017, 1, 1, 0, 0, 0,
+            tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
+
+        # We expect this method to not raise an exception
+        validator.is_edit_from_date_before_today(test_date)
+
+    def test_future_date_does_not_raise_exception(self):
+        """Assert that a future date does not raise an exception"""
+
+        test_date = datetime.datetime(
+            2020, 1, 1, 0, 0, 0,
+            tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
+
+        # We expect this method to not raise an exception
+        validator.is_edit_from_date_before_today(test_date)

--- a/frontend/src/components/MoEntry/MoAddressEntry.vue
+++ b/frontend/src/components/MoEntry/MoAddressEntry.vue
@@ -32,6 +32,7 @@
       class="address-date"
       v-model="entry.validity"
       :initially-hidden="validityHidden"
+      :disabled-dates="disabledDates"
     />
   </div>
 </template>
@@ -93,7 +94,12 @@ export default {
     facet: {
       type: String,
       required: true
-    }
+    },
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {

--- a/frontend/src/components/MoEntry/MoAssociationEntry.vue
+++ b/frontend/src/components/MoEntry/MoAssociationEntry.vue
@@ -32,6 +32,7 @@
     <mo-date-picker-range
       v-model="entry.validity"
       :initially-hidden="validityHidden"
+      :disabled-dates="disabledDates"
     />
   </div>
 </template>
@@ -63,7 +64,12 @@ export default {
     /**
      * This boolean property hides the validity.
      */
-    validityHidden: Boolean
+    validityHidden: Boolean,
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {

--- a/frontend/src/components/MoEntry/MoEmployeeAddressEntry.vue
+++ b/frontend/src/components/MoEntry/MoEmployeeAddressEntry.vue
@@ -6,6 +6,7 @@
     :required="required"
     :label="label"
     :preselectedType="preselectedType"
+    :disabled-dates="disabledDates"
   />
 </template>
 

--- a/frontend/src/components/MoEntry/MoEngagementEntry.vue
+++ b/frontend/src/components/MoEntry/MoEngagementEntry.vue
@@ -54,7 +54,12 @@ export default {
     /**
      * Defines the validity.
      */
-    validity: Object
+    validity: Object,
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {
@@ -80,9 +85,13 @@ export default {
      */
     orgUnitValidity () {
       if (this.entry.org_unit) {
-        return this.entry.org_unit.validity
+        let validityCopy = Object.assign({}, this.entry.org_unit.validity)
+        if (validityCopy.from < this.disabledDates.from) {
+          validityCopy.from = this.disabledDates.from
+        }
+        return validityCopy
       }
-      return {}
+      return this.disabledDates
     }
   },
 

--- a/frontend/src/components/MoEntry/MoItSystemEntry.vue
+++ b/frontend/src/components/MoEntry/MoItSystemEntry.vue
@@ -18,6 +18,7 @@
     <mo-date-picker-range
       v-model="entry.validity"
       :initially-hidden="validityHidden"
+      :disabled-dates="disabledDates"
     />
   </div>
 </template>
@@ -47,7 +48,12 @@ export default {
     /**
      * This boolean property hides validity.
      */
-    validityHidden: Boolean
+    validityHidden: Boolean,
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {

--- a/frontend/src/components/MoEntry/MoLeaveEntry.vue
+++ b/frontend/src/components/MoEntry/MoLeaveEntry.vue
@@ -11,6 +11,7 @@
     <mo-date-picker-range
       v-model="entry.validity"
       :initially-hidden="datePickerHidden"
+      :disabled-dates="disabledDates"
     />
   </div>
 </template>
@@ -38,7 +39,12 @@ export default {
     /**
      * Defines the validity.
      */
-    validity: Object
+    validity: Object,
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {

--- a/frontend/src/components/MoEntry/MoManagerAddressEntry.vue
+++ b/frontend/src/components/MoEntry/MoManagerAddressEntry.vue
@@ -6,6 +6,7 @@
     :required="required"
     :label="label"
     :preselectedType="preselectedType"
+    :disabled-dates="disabledDates"
   />
 </template>
 

--- a/frontend/src/components/MoEntry/MoManagerEntry.vue
+++ b/frontend/src/components/MoEntry/MoManagerEntry.vue
@@ -51,7 +51,11 @@
       small-buttons
     />
 
-    <mo-date-picker-range v-model="entry.validity" :initially-hidden="validityHidden"/>
+    <mo-date-picker-range
+      v-model="entry.validity"
+      :initially-hidden="validityHidden"
+      :disabled-dates="disabledDates"
+    />
   </div>
 </template>
 
@@ -95,7 +99,12 @@ export default {
     /**
      * This boolean property hide the employee picker.
      */
-    hideEmployeePicker: Boolean
+    hideEmployeePicker: Boolean,
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {

--- a/frontend/src/components/MoEntry/MoOrgUnitAddressEntry.vue
+++ b/frontend/src/components/MoEntry/MoOrgUnitAddressEntry.vue
@@ -6,6 +6,7 @@
     :required="required"
     :label="label"
     :preselectedType="preselectedType"
+    :disabled-dates="disabledDates"
   />
 </template>
 

--- a/frontend/src/components/MoEntry/MoOrganisationUnitEntry.vue
+++ b/frontend/src/components/MoEntry/MoOrganisationUnitEntry.vue
@@ -23,6 +23,7 @@
       <mo-date-picker-range
         v-model="orgUnit.validity"
         :disable-to-date="!creatingDate"
+        :disabled-dates="disabledDates"
       />
   </div>
 </template>
@@ -61,7 +62,12 @@ export default {
     /**
      * This boolean property able the date in create organisation component.
      */
-    creatingDate: Boolean
+    creatingDate: Boolean,
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {

--- a/frontend/src/components/MoEntry/MoRoleEntry.vue
+++ b/frontend/src/components/MoEntry/MoRoleEntry.vue
@@ -19,6 +19,7 @@
     <mo-date-picker-range
       v-model="entry.validity"
       :initially-hidden="validityHidden"
+      :disabled-dates="disabledDates"
     />
   </div>
 </template>
@@ -48,7 +49,12 @@ export default {
     /**
      * This boolean property hides the validity.
      */
-    validityHidden: Boolean
+    validityHidden: Boolean,
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates: Object
   },
 
   data () {

--- a/frontend/src/components/MoEntryEditModal.vue
+++ b/frontend/src/components/MoEntryEditModal.vue
@@ -22,6 +22,7 @@
         :disable-org-unit-picker="disableOrgUnitPicker"
         :hide-org-picker="hideOrgPicker"
         :hide-employee-picker="hideEmployeePicker"
+        :disabled-dates="disabledDates"
       />
 
       <div class="alert alert-danger" v-if="backendValidationMessage">
@@ -100,11 +101,10 @@ export default {
   data () {
     return {
       /**
-       * The entry, original, isLoading, backendValidationMessage component value.
+       * The entry, isLoading, backendValidationMessage component value.
        * Used to detect changes and restore the value.
        */
       entry: {},
-      original: {},
       isLoading: false,
       backendValidationMessage: null
     }
@@ -144,6 +144,15 @@ export default {
      */
     hasEntryComponent () {
       return this.entryComponent !== undefined
+    },
+
+    /**
+     * The valid dates for the entry component date pickers
+     */
+    disabledDates () {
+      return {
+        'from': new Date().toISOString().substring(0, 10)
+      }
     }
   },
 
@@ -183,11 +192,10 @@ export default {
 
   methods: {
     /**
-     * Handle the entry and original content.
+     * Handle the entry content.
      */
     handleContent (content) {
       this.entry = JSON.parse(JSON.stringify(content))
-      this.original = JSON.parse(JSON.stringify(content))
     },
 
     /**
@@ -204,7 +212,6 @@ export default {
       let data = {
         type: this.contentType,
         uuid: this.entry.uuid,
-        original: this.original,
         data: this.entry
       }
 

--- a/frontend/src/validators/DateInRange.js
+++ b/frontend/src/validators/DateInRange.js
@@ -16,8 +16,8 @@ export default {
   validate (value, range) {
     value = new Date(value)
 
-    let aboveMin = range.from ? value > new Date(range.from) : true
-    let belowMax = range.to ? value < new Date(range.to) : true
+    let aboveMin = range.from ? value >= new Date(range.from) : true
+    let belowMax = range.to ? value <= new Date(range.to) : true
 
     return aboveMin && belowMax
   }


### PR DESCRIPTION
This adds validation in front- and backend to ensure edits are not performed on dates before today's date.
Note, that this is not implemented for addresses, pending the rewrite and remodeling of these as discrete objects.

https://redmine.magenta-aps.dk/issues/25394

- ~Have you updated the documentation?~
- [x] Have you performed a smoke test of the application?
- [x] Have you written tests for your changes?
- [x] Have you updated the release notes?

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
