### PR TITLE
adjust styling and text for “no addresses” note

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -50,6 +50,8 @@ Bug fixes
 * #26898: Ensure that detail view for organisation mapper shows all
   related units.
 * #26788: Fixed the manager edit popup to submit with a blank employee picker field.
+* #26801: Adjust styling of missing address note for associations such
+  that it no longer appears as an error.
 
 Version 0.13.0, 2018-11-30
 ==========================

--- a/frontend/src/components/MoPicker/MoAddressPicker.vue
+++ b/frontend/src/components/MoPicker/MoAddressPicker.vue
@@ -158,6 +158,7 @@ export default {
 <style scoped>
  .no-address {
     margin-top: 2.5rem;
-    color: #ff0000;
+    opacity: 0.5;
+    font-style: italic;
   }
 </style>

--- a/frontend/src/locales/da/input_fields.json
+++ b/frontend/src/locales/da/input_fields.json
@@ -21,7 +21,7 @@
   "role_type": "@:shared.role_type",
   "search_for_employee": "Søg efter medarbejder",
   "search_entire_country": "Søg i hele landet",
-  "no_addresses_associated_to_org_unit": "Ingen adresser er tilknyttet til enheden",
+  "no_addresses_associated_to_org_unit": "Ingen adresser",
   "select_new_super_unit": "Angiv ny overenhed",
   "start_date": "@:shared.date.start_date",
   "super_unit": "Overenhed",


### PR DESCRIPTION
Everything else just works, but it's no longer styled like an error. I also added a test.

<!-- Insert a link for relevant Redmine ticket(s) here -->

- [x] ~Have you updated the documentation?~ N/A
- [x] Have you performed a smoke test of the application?
- [x] Have you written tests for your changes?
- [x] Have you updated the release notes?

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->

### Before

![create-employ-assoc-no-address-1](https://user-images.githubusercontent.com/59300/52416456-e6d55d00-2ae9-11e9-81db-ef248eb66c7c.png)

## After

![create-employ-assoc-no-address-2](https://user-images.githubusercontent.com/59300/52416472-f2c11f00-2ae9-11e9-89e7-25a9e726f7cc.png)
