### PR TITLE
tests: remove patching that belongs in LoRA upstream

### DIFF
--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -543,10 +543,6 @@ class LoRATestCaseMixin(test_support.TestCaseMixin, TestCaseMixin):
                 self.lora_port,
             )),
             patch('oio_rest.app.settings.LOG_AMQP_SERVER', None),
-            patch('oio_rest.validate.SCHEMA', None),
-            patch('mora.importing.processors._fetch.cache', {}),
-            patch('mora.importing.processors._fetch.cache_file',
-                  os.devnull),
         ]
 
         # apply patches, then start the server -- so they're active

--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -542,7 +542,6 @@ class LoRATestCaseMixin(test_support.TestCaseMixin, TestCaseMixin):
             patch('mora.settings.LORA_URL', 'http://localhost:{}/'.format(
                 self.lora_port,
             )),
-            patch('oio_rest.app.settings.LOG_AMQP_SERVER', None),
         ]
 
         # apply patches, then start the server -- so they're active


### PR DESCRIPTION
We have `test_support` now; anything that touches LoRA internals
belongs there, so that we can modify it exclusively upstream.

<!-- Insert a link for relevant Redmine ticket(s) here -->

- [x] ~Have you updated the documentation?~ N/A
- [x] ~Have you performed a smoke test of the application?~ N/A
- [x] ~Have you written tests for your changes?~ N/A
- [x] ~Have you updated the release notes?~ N/A

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->