### PR TITLE
#27228 & #26402 mapping fixes

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,8 @@ Bug fixes
 
 * #27228: Clicking the “Save” button in the organisation mapper now
   shows a confirmation that the operation succeeded.
+* #26402: The “Save” button on the organisation mapper now correctly
+  deactivates when successfully saving changes.
 
 Version 0.15.0, in development
 ==============================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,12 @@
+Version 0.16.0, in development
+==============================
+
+Bug fixes
+---------
+
+* #27228: Clicking the “Save” button in the organisation mapper now
+  shows a confirmation that the operation succeeded.
+
 Version 0.15.0, in development
 ==============================
 

--- a/frontend/e2e-tests/MoOrganisationUnitMapper.js
+++ b/frontend/e2e-tests/MoOrganisationUnitMapper.js
@@ -160,8 +160,8 @@ test('Writing mapping', async t => {
       /Organisationsenheden med UUID [-0-9a-f]* er blevet redigeret/
     )
 
-  // FIXME: we should disable the button after a save
-    // .expect(saveButton.getAttribute('disabled')).ok()
+  // verify that we disable the button after a save
+    .expect(saveButton.getAttribute('disabled')).ok()
 
   // reload the page
     .expect(reload()).notOk()

--- a/frontend/e2e-tests/MoOrganisationUnitMapper.js
+++ b/frontend/e2e-tests/MoOrganisationUnitMapper.js
@@ -25,6 +25,8 @@ const getPagePath = ClientFunction(() => window.location.pathname);
 const tabs = VueSelector('organisation-detail-tabs bTabButtonHelper')
 const links = VueSelector('mo-table-detail mo-link')
 
+const latestLog = VueSelector('MoLog').find('.alert').nth(0)
+
 test('View no mapping', async t => {
   await t
     .click(mapperButton)
@@ -151,6 +153,12 @@ test('Writing mapping', async t => {
     .expect(saveButton.getAttribute('disabled')).notOk()
 
     .click(saveButton)
+
+  // we logged something, right?
+    .expect(latestLog.innerText)
+    .match(
+      /Organisationsenheden med UUID [-0-9a-f]* er blevet redigeret/
+    )
 
   // FIXME: we should disable the button after a save
     // .expect(saveButton.getAttribute('disabled')).ok()

--- a/frontend/src/api/HttpCommon.js
+++ b/frontend/src/api/HttpCommon.js
@@ -33,8 +33,5 @@ export default {
       })
   },
 
-  post (url, payload) {
-    return Service
-      .post(url, payload)
-  }
+  post: Service.post
 }

--- a/frontend/src/modules/organisationMapper/_store/index.js
+++ b/frontend/src/modules/organisationMapper/_store/index.js
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal'
 import moment from 'moment'
 import Service from '@/api/HttpCommon'
 
@@ -8,7 +9,7 @@ const state = {
 }
 
 const actions = {
-  MAP_ORGANISATIONS ({ commit, state }) {
+  MAP_ORGANISATIONS ({ commit, dispatch, state }) {
     Service.post(
       `/ou/${state.origin}/map`,
       {
@@ -22,6 +23,8 @@ const actions = {
         commit('log/newWorkLog',
           { type: 'ORGANISATION_EDIT', value: state.origin },
           { root: true })
+
+        dispatch('GET_ORGANISATION_MAPPINGS')
       })
       .catch(error => {
         commit('log/newError',
@@ -61,9 +64,14 @@ const mutations = {
 const getters = {
   origin: state => state.origin,
   destination: state => state.destination,
-  original_destination: state => state.raw_destination.flatMap(
-    func => func.org_unit.map(ou => ou.uuid).filter(id => id !== state.origin)
-  )
+  isDirty: state => {
+    let orig = new Set(
+      state.raw_destination.flatMap(
+        func => func.org_unit.map(ou => ou.uuid).filter(id => id !== state.origin)
+      )
+    )
+    return !isEqual(new Set(state.destination), orig)
+  }
 }
 
 export default {

--- a/frontend/src/modules/organisationMapper/_store/index.js
+++ b/frontend/src/modules/organisationMapper/_store/index.js
@@ -8,8 +8,9 @@ const state = {
 }
 
 const actions = {
-  MAP_ORGANISATIONS ({ state }) {
-    Service.post(`/ou/${state.origin}/map`,
+  MAP_ORGANISATIONS ({ commit, state }) {
+    Service.post(
+      `/ou/${state.origin}/map`,
       {
         destination: state.destination,
         validity: {
@@ -17,8 +18,16 @@ const actions = {
         }
       }
     )
+      .then(result => {
+        commit('log/newWorkLog',
+          { type: 'ORGANISATION_EDIT', value: state.origin },
+          { root: true })
+      })
       .catch(error => {
-        console.log(error.response)
+        commit('log/newError',
+          { type: 'ERROR', value: error.response },
+          { root: true })
+        return error
       })
   },
 

--- a/frontend/src/modules/organisationMapper/index.vue
+++ b/frontend/src/modules/organisationMapper/index.vue
@@ -13,7 +13,7 @@
           class="mt-2 btn btn-primary btn-submit"
           :disabled="!valid"
         >
-          <icon name="map-signs"/>
+          <icon name="sitemap"/>
           {{$t('buttons.save')}}
         </button>
       </div>

--- a/frontend/src/modules/organisationMapper/index.vue
+++ b/frontend/src/modules/organisationMapper/index.vue
@@ -11,7 +11,7 @@
         <button
           @click="onSubmit"
           class="mt-2 btn btn-primary btn-submit"
-          :disabled="!valid"
+          :disabled="!isDirty"
         >
           <icon name="sitemap"/>
           {{$t('buttons.save')}}
@@ -46,7 +46,6 @@
 </template>
 
 <script>
-import isEqualTo from 'lodash.isequal'
 import MoTreeView from '@/components/MoTreeView/MoTreeView'
 import MoLog from '@/components/MoLog/MoLog'
 import { mapGetters } from 'vuex'
@@ -81,12 +80,8 @@ export default {
       }
     },
 
-    valid () {
-      return this.origin && !isEqualTo(this.original_destination, this.destination)
-    },
-
     ...mapGetters({
-      original_destination: 'organisationMapper/original_destination'
+      isDirty: 'organisationMapper/isDirty'
     })
   },
 

--- a/frontend/src/modules/organisationMapper/index.vue
+++ b/frontend/src/modules/organisationMapper/index.vue
@@ -37,12 +37,18 @@
         </div>
       </div>
     </div>
+    <div class="row">
+      <div class="col">
+        <mo-log class="card"/>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
 import isEqualTo from 'lodash.isequal'
 import MoTreeView from '@/components/MoTreeView/MoTreeView'
+import MoLog from '@/components/MoLog/MoLog'
 import { mapGetters } from 'vuex'
 import store from './_store'
 import mainStore from '@/store'
@@ -52,6 +58,7 @@ mainStore.registerModule('organisationMapper', store)
 export default {
   name: 'OrganisationMapperModule',
   components: {
+    MoLog,
     MoTreeView
   },
   computed: {


### PR DESCRIPTION
<!-- Insert a link for relevant Redmine ticket(s) here -->

https://redmine.magenta-aps.dk/issues/26402
https://redmine.magenta-aps.dk/issues/27228

This PR addresses two bugs in the organisation mapper. #27228 fixes so that we report successful saves. Errors, however, don't work _terribly_ well, but AFAICT that's a persistent issue throughout the UI. I stumbled upon a fix for #26402, so I fixed that one as well; this makes it so the save button correctly disables after a save.

- [x] ~Have you updated the documentation?~ N/A
- [x] Have you performed a smoke test of the application?
- [x] Have you written tests for your changes?
- [x] Have you updated the release notes?

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->

![Screenshot 2019-03-12 at 13 42 45](https://user-images.githubusercontent.com/59300/54200945-c0ca2080-44cc-11e9-81e6-05ed923b63a9.png)
