### PR TITLE
e2e-tests: ensure that we reset database in the tab tests

### DIFF
--- a/frontend/e2e-tests/MoEmployeeAssociationTab.js
+++ b/frontend/e2e-tests/MoEmployeeAssociationTab.js
@@ -1,10 +1,11 @@
 import VueSelector from 'testcafe-vue-selectors'
 import { Selector } from 'testcafe'
-import { baseURL } from './support'
+import { baseURL, reset } from './support'
 
 let moment = require('moment')
 
 fixture('MoEmployeeAssociationTab')
+  .beforeEach(reset)
   .page(`${baseURL}/medarbejder/`)
 
 const dialog = Selector('.modal-content')

--- a/frontend/e2e-tests/MoOrganisationManagerTab.js
+++ b/frontend/e2e-tests/MoOrganisationManagerTab.js
@@ -1,10 +1,11 @@
 import VueSelector from 'testcafe-vue-selectors'
 import { Selector } from 'testcafe'
-import { baseURL } from './support'
+import { baseURL, reset } from './support'
 
 let moment = require('moment')
 
 fixture('MoOrganisationManagerTab')
+  .beforeEach(reset)
   .page(`${baseURL}/organisation/a6773531-6c0a-4c7b-b0e2-77992412b610`)
 
 const dialog = Selector('.modal-content')


### PR DESCRIPTION
<!-- Insert a link for relevant Redmine ticket(s) here -->

This just fixes a minor oversight when updating #317; tests now require an extra call to reset the database. This relies on an endpoint available both during the test run and the `full-run`, and invoked after each test. I'd like to have it invoked _before_, but ran into some issues with early queries failing.

- [ ] Have you updated the documentation?
- [ ] Have you performed a smoke test of the application?
- [ ] Have you written tests for your changes?
- [ ] Have you updated the release notes?

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
