### PR TITLE
Bugfix/29200 data visualization

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,6 +12,8 @@ Bug fixes
 
 * #29019: Never ending loop in manager inheritance
 * #28017: Changed style for user settings - location and user key.
+* #29200: We now properly clear the store when switching org units/employees
+  to prevent 'old data' from showing.
 
 Internal changes
 ----------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -14,6 +14,7 @@ Bug fixes
 * #28017: Changed style for user settings - location and user key.
 * #29200: We now properly clear the store when switching org units/employees
   to prevent 'old data' from showing.
+* #29200: Fixed spinners when loading table data.
 
 Internal changes
 ----------------

--- a/frontend/src/components/MoTable/MoTable.vue
+++ b/frontend/src/components/MoTable/MoTable.vue
@@ -138,11 +138,6 @@ export default {
     columns: Array,
 
     /**
-     * True during rendering or loading of the component.
-     */
-    isLoading: Boolean,
-
-    /**
      * Defines the editComponent.
      */
     editComponent: Object,
@@ -175,7 +170,8 @@ export default {
       selectAll: false,
       selected: [],
       open: {},
-      sortableContent: null
+      sortableContent: null,
+      isLoading: true
     }
   },
 
@@ -220,6 +216,7 @@ export default {
      */
     content () {
       this.sortableContent = this.content
+      this.isLoading = false
     },
     deep: true
   },

--- a/frontend/src/views/employee/EmployeeDetail.vue
+++ b/frontend/src/views/employee/EmployeeDetail.vue
@@ -68,6 +68,7 @@ export default {
   },
 
   created () {
+    this.$store.commit(Employee.mutations.RESET_EMPLOYEE)
     this.$store.dispatch(Employee.actions.SET_EMPLOYEE, this.$route.params.uuid)
   },
   mounted () {
@@ -78,12 +79,9 @@ export default {
   methods: {
     loadContent (event) {
       this.latestEvent = event
+      this.$store.dispatch(Employee.actions.SET_EMPLOYEE, this.$route.params.uuid)
       this.$store.dispatch(Employee.actions.SET_DETAIL, event)
     }
-  },
-  beforeRouteLeave (to, from, next) {
-    this.$store.commit(Employee.mutations.RESET_EMPLOYEE)
-    next()
   }
 
 }

--- a/frontend/src/views/organisation/OrganisationDetail.vue
+++ b/frontend/src/views/organisation/OrganisationDetail.vue
@@ -74,6 +74,7 @@ export default {
     })
   },
   created () {
+    this.$store.commit(OrganisationUnit.mutations.RESET_ORG_UNIT)
     this.$store.dispatch(OrganisationUnit.actions.SET_ORG_UNIT, this.route.params.uuid)
   },
   mounted () {
@@ -84,14 +85,9 @@ export default {
   methods: {
     loadContent (event) {
       this.latestEvent = event
-
       this.$store.dispatch(OrganisationUnit.actions.SET_ORG_UNIT, this.route.params.uuid)
       this.$store.dispatch(OrganisationUnit.actions.SET_DETAIL, event)
     }
-  },
-  beforeRouteLeave (to, from, next) {
-    this.$store.commit(OrganisationUnit.mutations.RESET_ORG_UNIT)
-    next()
   }
 }
 </script>


### PR DESCRIPTION
https://redmine.magenta-aps.dk/issues/29200

- [ ] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] ~Tests have been written/updated for my change~
- [ ] ~The documentation has been updated~
    - [ ] ~The documentation builds without warnings or errors~
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `I test`

**If applicable:**

- [x] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->

---

The underlying store in the UI is now cleared whenever we select a new org unit or employee, to prevent old data from spilling over until the new data has been fetched.

![spinner](https://user-images.githubusercontent.com/1827127/58165129-61844b80-7c87-11e9-838d-8f5e223ef6af.png)

Spinners have now been added (or reenabled, rather) to make it clear when data in the various tables are still being fetched. This is to make a clearer distinction between when an API call is successful, but no data is found and when the backend API call failed for some reason.
