### PR TITLE
Bugfix/29200 unregister event listeners

### DIFF
--- a/frontend/src/views/employee/EmployeeDetail.vue
+++ b/frontend/src/views/employee/EmployeeDetail.vue
@@ -72,15 +72,19 @@ export default {
     this.$store.dispatch(Employee.actions.SET_EMPLOYEE, this.$route.params.uuid)
   },
   mounted () {
-    EventBus.$on(Events.EMPLOYEE_CHANGED, () => {
-      this.loadContent(this.latestEvent)
-    })
+    EventBus.$on(Events.EMPLOYEE_CHANGED, this.listener)
+  },
+  beforeDestroy () {
+    EventBus.$off(Events.EMPLOYEE_CHANGED, this.listener)
   },
   methods: {
     loadContent (event) {
       this.latestEvent = event
-      this.$store.dispatch(Employee.actions.SET_EMPLOYEE, this.$route.params.uuid)
       this.$store.dispatch(Employee.actions.SET_DETAIL, event)
+    },
+    listener () {
+      this.$store.dispatch(Employee.actions.SET_EMPLOYEE, this.$route.params.uuid)
+      this.loadContent(this.latestEvent)
     }
   }
 

--- a/frontend/src/views/organisation/OrganisationDetail.vue
+++ b/frontend/src/views/organisation/OrganisationDetail.vue
@@ -78,15 +78,19 @@ export default {
     this.$store.dispatch(OrganisationUnit.actions.SET_ORG_UNIT, this.route.params.uuid)
   },
   mounted () {
-    EventBus.$on(Events.ORGANISATION_UNIT_CHANGED, () => {
-      this.loadContent(this.latestEvent)
-    })
+    EventBus.$on(Events.ORGANISATION_UNIT_CHANGED, this.listener)
+  },
+  beforeDestroy () {
+    EventBus.$off(Events.ORGANISATION_UNIT_CHANGED, this.listener)
   },
   methods: {
     loadContent (event) {
       this.latestEvent = event
-      this.$store.dispatch(OrganisationUnit.actions.SET_ORG_UNIT, this.route.params.uuid)
       this.$store.dispatch(OrganisationUnit.actions.SET_DETAIL, event)
+    },
+    listener () {
+      this.$store.dispatch(OrganisationUnit.actions.SET_ORG_UNIT, this.route.params.uuid)
+      this.loadContent(this.latestEvent)
     }
   }
 }


### PR DESCRIPTION
https://redmine.magenta-aps.dk/issues/29200

- [ ] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [ ] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `I test`

**If applicable:**

- [x] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->

---

When orgunit/employee UI components are created, they register event listeners meant to update the store when an orgunit/employee has been changed with an edit or create. These listeners were never removed, causing each UI component created to react to these events

This has been resolved now, so only the currently active component has a listener.
