### PR TITLE
Remove Jenkins deployment hook

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,17 +63,6 @@ pipeline {
       }
     }
 
-    stage('Deploy') {
-      steps {
-        timeout(5) {
-          ansiColor('xterm') {
-            dir("backend") {
-              sh './.jenkins/4-deploy.sh'
-            }
-          }
-        }
-      }
-    }
   }
 
   post {


### PR DESCRIPTION
The current deployment setup is too unstable, so it will be removed
until it can be replaced with the new Gitlab setup

https://redmine.magenta-aps.dk/issues/INSERT_ISSUE_NUMBER

- [x] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [ ] The application can be built and installed without errors
- [ ] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [ ] Release notes have been updated
- [ ] The corresponding Redmine ticket has been set to `I test`

**If applicable:**

- [ ] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
