### PR TITLE
terminate: don't restrict termination dates beyond now and onwards

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,8 @@ Bug fixes
 * #29761: Date pickers moved to the top of the various forms
 * #30093: The shown units in the organisation unit pickers now reflect
     the dates selected in the date pickers
+* #29669: Fix terminating units past any date they've been changed in
+  the future.
 
 New features
 ------------

--- a/frontend/src/views/organisation/workflows/MoOrganisationUnitTerminate.vue
+++ b/frontend/src/views/organisation/workflows/MoOrganisationUnitTerminate.vue
@@ -55,6 +55,7 @@
  * A organisation unit terminate component.
  */
 
+import moment from 'moment'
 import OrganisationUnit from '@/api/OrganisationUnit'
 import { MoInputDate } from '@/components/MoInput'
 import MoOrganisationUnitPicker from '@/components/MoPicker/MoOrganisationUnitPicker'
@@ -97,7 +98,10 @@ export default {
      * Check if the organisation date are valid.
      */
     validDates () {
-      return this.org_unit ? this.org_unit.validity : {}
+      return {
+          from: moment().format('YYYY-MM-DD'),
+          to: null
+      }
     },
 
     ...mapGetters({


### PR DESCRIPTION
The frontend doesn't actually know when a given unit terminates;
rather it knows how long the current values remain unchanged.
Restricting termination dates to those values prevents terminating a
unit after the next change in its properties.

Rather, we simply allow selecting _any_ termination date in the
future. Should the user pick a date where a unit no longer exists,
they can't pick that unit. Should they pick a unit, and _then_ pick a
date, the unit will simply deselect if it no longer exists.

https://redmine.magenta-aps.dk/issues/29669

- [ ] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [x] Changes have been made to the UI
    - [x] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
