### PR TITLE
#29569 validate address when editing

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,8 @@ Bug fixes
   rather than e.g. the creation date of an old unit.
 * #30095: Address missing error in CPR search by automatically
   performing said search. And filter out any dashes while at it.
+* #29569: Validate addresses related to their unit and employee when
+  editing rather than merely at creation.
 
 New features
 ------------

--- a/backend/mora/service/address.py
+++ b/backend/mora/service/address.py
@@ -177,8 +177,8 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
         scope = mapping.SINGLE_ADDRESS_FIELD(effect)[0].get('objekttype')
         handler = base.get_handler_for_scope(scope).from_effect(effect)
 
-        person = list(mapping.USER_FIELD.get_uuids(effect))
-        org_unit = list(mapping.ASSOCIATED_ORG_UNIT_FIELD.get_uuids(effect))
+        person = mapping.USER_FIELD.get_uuid(effect)
+        org_unit = mapping.ASSOCIATED_ORG_UNIT_FIELD.get_uuid(effect)
 
         func = {
             mapping.ADDRESS_TYPE: address_type,
@@ -193,10 +193,10 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
         }
         if person:
             func[mapping.PERSON] = employee.get_one_employee(
-                c, person[0])
+                c, person)
         if org_unit:
             func[mapping.ORG_UNIT] = orgunit.get_one_orgunit(
-                c, org_unit[0],
+                c, org_unit,
                 details=orgunit.UnitDetails.MINIMAL)
 
         if props.get('integrationsdata') is not None:
@@ -279,6 +279,12 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
         if not original:
             exceptions.ErrorCodes.E_NOT_FOUND()
 
+        # Get org unit uuid for validation purposes
+        org_unit_uuid = mapping.ASSOCIATED_ORG_UNIT_FIELD.get_uuid(original)
+
+        # Get employee uuid for validation purposes
+        employee_uuid = mapping.USER_FIELD.get_uuid(original)
+
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
@@ -318,20 +324,21 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
         ]
 
         if mapping.PERSON in data:
+            employee_uuid = util.get_mapping_uuid(data, mapping.PERSON)
             update_fields.append((
                 mapping.USER_FIELD,
                 {
-                    'uuid':
-                        util.get_mapping_uuid(data, mapping.PERSON),
+                    'uuid': employee_uuid,
                 },
             ))
 
         if mapping.ORG_UNIT in data:
+            org_unit_uuid = util.get_mapping_uuid(data, mapping.ORG_UNIT)
+
             update_fields.append((
                 mapping.ASSOCIATED_ORG_UNIT_FIELD,
                 {
-                    'uuid':
-                        util.get_mapping_uuid(data, mapping.ORG_UNIT),
+                    'uuid': org_unit_uuid,
                 },
             ))
 
@@ -393,7 +400,13 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
 
         self.payload = payload
         self.uuid = function_uuid
-        self.org_unit_uuid = (
-            mapping.ASSOCIATED_ORG_UNIT_FIELD.get_uuid(original)
-        )
-        self.employee_uuid = mapping.USER_FIELD.get_uuid(original)
+        self.org_unit_uuid = org_unit_uuid
+        self.employee_uuid = employee_uuid
+
+        if org_unit_uuid:
+            validator.is_date_range_in_org_unit_range({'uuid': org_unit_uuid},
+                                                      new_from, new_to)
+
+        if employee_uuid:
+            validator.is_date_range_in_employee_range({'uuid': employee_uuid},
+                                                      new_from, new_to)

--- a/backend/mora/service/engagement.py
+++ b/backend/mora/service/engagement.py
@@ -101,7 +101,7 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
             original, mapping.USER_FIELD.path)[-1]
         employee_uuid = util.get_uuid(employee, required=True)
 
-        data = req.get('data')
+        data = util.checked_get(req, 'data', {}, required=True)
         new_from, new_to = util.get_validities(data)
 
         validator.is_edit_from_date_before_today(new_from)

--- a/backend/mora/service/engagement.py
+++ b/backend/mora/service/engagement.py
@@ -92,14 +92,10 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
         original = c.organisationfunktion.get(uuid=engagement_uuid)
 
         # Get org unit uuid for validation purposes
-        org_unit = util.get_obj_value(
-            original, mapping.ASSOCIATED_ORG_UNIT_FIELD.path)[-1]
-        org_unit_uuid = util.get_uuid(org_unit)
+        org_unit_uuid = mapping.ASSOCIATED_ORG_UNIT_FIELD.get_uuid(original)
 
         # Get employee uuid for validation purposes
-        employee = util.get_obj_value(
-            original, mapping.USER_FIELD.path)[-1]
-        employee_uuid = util.get_uuid(employee, required=True)
+        employee_uuid = mapping.USER_FIELD.get_uuid(original)
 
         data = util.checked_get(req, 'data', {}, required=True)
         new_from, new_to = util.get_validities(data)
@@ -150,11 +146,10 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
             ))
 
         if mapping.ORG_UNIT in data:
-            org_unit_uuid = data.get(mapping.ORG_UNIT).get('uuid')
-            update_fields.append((
-                mapping.ASSOCIATED_ORG_UNIT_FIELD,
-                {'uuid': org_unit_uuid},
-            ))
+            org_unit_uuid = util.get_mapping_uuid(data, mapping.ORG_UNIT,
+                                                  required=True)
+            update_fields.append((mapping.ASSOCIATED_ORG_UNIT_FIELD,
+                                  {'uuid': org_unit_uuid}))
 
         # Attribute extensions
         new_extensions = {}
@@ -195,10 +190,10 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
         payload = common.ensure_bounds(new_from, new_to, bounds_fields,
                                        original, payload)
 
-        validator.is_date_range_in_org_unit_range(org_unit, new_from,
-                                                  new_to)
-        validator.is_date_range_in_employee_range(employee, new_from,
-                                                  new_to)
+        validator.is_date_range_in_org_unit_range({'uuid': org_unit_uuid},
+                                                  new_from, new_to)
+        validator.is_date_range_in_employee_range({'uuid': employee_uuid},
+                                                  new_from, new_to)
 
         self.payload = payload
         self.uuid = engagement_uuid

--- a/backend/mora/service/handlers.py
+++ b/backend/mora/service/handlers.py
@@ -100,6 +100,7 @@ class RequestHandler(metaclass=_RequestHandlerMeta):
 
         if self.request_type == RequestType.EDIT:
             request = request['data']
+
         self.prepare_amqp_message(request)
 
     def prepare_amqp_message(self, request: dict):

--- a/backend/tests/test_integration_engagement.py
+++ b/backend/tests/test_integration_engagement.py
@@ -566,15 +566,19 @@ class Tests(util.LoRATestCase):
 
         self.assertRequestResponse(
             '/service/details/edit',
-            # NB: not a helpful error :(
             {
-                'description': "'NoneType' object is not subscriptable",
+                'description': "Missing data",
                 'error': True,
-                'error_key': 'E_UNKNOWN',
-                'status': 500,
+                'error_key': 'V_MISSING_REQUIRED_VALUE',
+                'status': 400,
+                'key': 'data',
+                'obj': {
+                    'type': 'engagement',
+                    'uuid': '00000000-0000-0000-0000-000000000000',
+                },
             },
             json=payload,
-            status_code=500,
+            status_code=400,
         )
 
     def test_create_engagement_fails_on_missing_unit(self):


### PR DESCRIPTION
This change ensures that we validate addresses not only on creation, but also when editing. During fixing this bug, I noticed that `engagement` had a possible bug where we validated w.r.t. to previous values during editing.

https://redmine.magenta-aps.dk/issues/29569

- [ ] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [ ] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [ ] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
