### PR TITLE
#29700 focus current date in dropdowns

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,8 @@ Bug fixes
     the dates selected in the date pickers
 * #29669: Fix terminating units past any date they've been changed in
   the future.
+* #29700: Ensure that date dropdowns always focus a selectable date,
+  rather than e.g. the creation date of an old unit.
 
 New features
 ------------

--- a/frontend/src/components/MoInput/MoInputDate.vue
+++ b/frontend/src/components/MoInput/MoInputDate.vue
@@ -4,6 +4,7 @@
 
     <date-time-picker
       v-model="internalValue"
+      :open-date="initialValue"
       format="dd-MM-yyyy"
       :language="da"
       monday-first
@@ -63,6 +64,23 @@ export default {
   },
 
   computed: {
+    /**
+     * The initially focused value. Use either the current value or the
+     * closest allowed value.
+     */
+    initialValue () {
+      let currentDate = this.internalValue ? new Date(this.internalValue) :
+      new Date()
+      let disabled = this.disabledDates
+
+      if (disabled.to && currentDate <= disabled.to)
+        return disabled.to
+      else if (disabled.from && currentDate < disabled.from)
+        return disabled.from
+      else
+        return currentDate
+    },
+
     /**
      * Date interval to disable.
      * We flip the validTo dates, as we want to disable anything outside of the range.


### PR DESCRIPTION
This changes is so that we focus the current date in dropdowns where that's the minimum valid value. I'm not entirely certain that this was the issue in the reported bug, but it's a major annoyance and my best guess.

Previously, the date picker would always pop up to the current value, even when that value was disallowed. Instead, clamp whatever we display to the allowable values. With our test data, this avoids the need for flipping from somewhere in the sixties to today in certain circumstances. That's just obnoxious…

https://redmine.magenta-aps.dk/issues/29700

- [ ] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [ ] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [x] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
