### PR TITLE
docs: fix generating CLI docs; use mock

### DIFF
--- a/backend/requirements-docs.txt
+++ b/backend/requirements-docs.txt
@@ -6,4 +6,3 @@ sphinxcontrib-httpdomain>=1.6.0
 sphinxcontrib-apidoc>=0.2.1
 sphinx-click>=1.0.3
 recommonmark>=0.4.0
-pika==0.13.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,8 @@ MOCK_MODULES = [
     'flask_saml_sso',
     'validators',
     'psycopg2',
+    'sqlalchemy',
+    'pika',
 
     'onelogin',
     'onelogin.saml2',


### PR DESCRIPTION
I noticed that the docs lacked the CLI documentation.

---

https://redmine.magenta-aps.dk/issues/INSERT_ISSUE_NUMBER

- [x] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [ ] The application can be built and installed without errors
- [ ] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [ ] Release notes have been updated
- [ ] The corresponding Redmine ticket has been set to `Needs review`
    - [ ] The issue has a link to this PR

**If applicable:**

- [ ] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
