### PR TITLE
#29570 move validations

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -23,6 +23,8 @@ Bug fixes
   performing said search. And filter out any dashes while at it.
 * #29569: Validate addresses related to their unit and employee when
   editing rather than merely at creation.
+* #29570: Ensure the error messages when validating a unit move are correct
+  and in the correct locations.
 
 New features
 ------------

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -270,8 +270,12 @@ class OrgUnitRequestHandler(handlers.ReadingRequestHandler):
 
         if mapping.PARENT in data:
             parent_uuid = util.get_mapping_uuid(data, mapping.PARENT)
-            validator.is_candidate_parent_valid(unitid,
-                                                parent_uuid, new_from)
+
+            if parent_uuid != mapping.PARENT_FIELD.get_uuid(original):
+                validator.is_movable_org_unit(unitid)
+
+            validator.is_candidate_parent_valid(unitid, parent_uuid, new_from)
+
             update_fields.append((
                 mapping.PARENT_FIELD,
                 {'uuid': parent_uuid}

--- a/backend/mora/service/validation/validate.py
+++ b/backend/mora/service/validation/validate.py
@@ -238,6 +238,18 @@ def employee_existing_associations():
     return flask.jsonify(success=True)
 
 
+@blueprint.route('/movable-org-unit/', methods=['POST'])
+@util.restrictargs()
+def movable_org_unit():
+    req = flask.request.get_json()
+
+    org_unit_uuid = util.get_mapping_uuid(req, mapping.ORG_UNIT, required=True)
+
+    validator.is_movable_org_unit(org_unit_uuid)
+
+    return flask.jsonify(success=True)
+
+
 @blueprint.route('/candidate-parent-org-unit/', methods=['POST'])
 @util.restrictargs()
 def candidate_parent_org_unit():

--- a/backend/mora/service/validation/validator.py
+++ b/backend/mora/service/validation/validator.py
@@ -216,6 +216,20 @@ def is_contained_in_range(candidate_from, candidate_to, valid_from, valid_to,
 
 
 @forceable
+def is_movable_org_unit(unitid):
+    # Do not allow moving of the root org unit
+    c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
+    unit = c.organisationenhed.get(unitid)
+
+    orgid = mapping.BELONGS_TO_FIELD.get_uuid(unit)
+    parentid = mapping.PARENT_FIELD.get_uuid(unit)
+
+    if parentid == orgid:
+        exceptions.ErrorCodes.V_CANNOT_MOVE_ROOT_ORG_UNIT()
+
+
+@forceable
 def is_candidate_parent_valid(unitid: str, parent: str,
                               from_date: datetime.datetime) -> bool:
     """
@@ -235,9 +249,6 @@ def is_candidate_parent_valid(unitid: str, parent: str,
         uuid=unitid
     )['relationer']
     orgid = org_unit_relations['tilhoerer'][0]['uuid']
-
-    if org_unit_relations['overordnet'][0]['uuid'] == orgid:
-        exceptions.ErrorCodes.V_CANNOT_MOVE_ROOT_ORG_UNIT()
 
     if parent == orgid:
         exceptions.ErrorCodes.V_CANNOT_MOVE_UNIT_TO_ROOT_LEVEL()

--- a/frontend/src/api/Validate.js
+++ b/frontend/src/api/Validate.js
@@ -78,6 +78,19 @@ export default {
       })
   },
 
+  isMovableOrgUnit (orgUnit) {
+    const payload = {
+      'org_unit': orgUnit,
+    }
+
+    return Validate
+      .post('/movable-org-unit/', payload).then(result => {
+        return true
+      }, err => {
+        return createErrorPayload(err)
+      })
+  },
+
   candidateParentOrgUnit (orgUnit, parent, validity) {
     const payload = {
       'org_unit': orgUnit,

--- a/frontend/src/api/Validate.js
+++ b/frontend/src/api/Validate.js
@@ -78,7 +78,7 @@ export default {
       })
   },
 
-  candidateParentOrgUnit (orgUnit, parent, validity, associationUuid) {
+  candidateParentOrgUnit (orgUnit, parent, validity) {
     const payload = {
       'org_unit': orgUnit,
       'parent': parent,

--- a/frontend/src/components/MoPicker/MoOrganisationUnitPicker.vue
+++ b/frontend/src/components/MoPicker/MoOrganisationUnitPicker.vue
@@ -146,11 +146,16 @@ export default {
 
       this.orgName = unit.name
       this.orgUnitUuid = unit.uuid
-      this.$validator.validate(this.nameId)
       this.$refs[this.nameId].blur()
       this.showTree = false
 
-      this.$emit('input', unit)
+      await this.$emit('input', unit)
+
+      // NB: we don't perform validations until _after_ we've notified
+      // the model using the event above. this avoids a race condition
+      // where the extraValidations refer to our model (see #29570)
+      this.$validator.validate(this.nameId)
+
     },
 
     async validity (newVal, oldVal) {

--- a/frontend/src/components/MoPicker/MoOrganisationUnitPicker.vue
+++ b/frontend/src/components/MoPicker/MoOrganisationUnitPicker.vue
@@ -17,6 +17,7 @@
 
     <div class="mo-input-group" v-show="showTree">
       <mo-tree-view v-model="selectedSuperUnitUuid"
+                    :disabled-unit="disabledUnit && disabledUnit.uuid"
                     :at-date="validity && validity.from"/>
     </div>
 
@@ -78,6 +79,11 @@ export default {
       type: [Object, undefined],
       required: false
     },
+
+    /**
+     * Unselectable unit.
+     */
+    disabledUnit: Object,
 
     /**
      * An object of additional validations to be performed

--- a/frontend/src/validators/MovableOrgUnit.js
+++ b/frontend/src/validators/MovableOrgUnit.js
@@ -1,0 +1,12 @@
+import Validate from '@/api/Validate'
+import common from './common.js'
+
+export default {
+  validate (value, args) {
+    let orgUnit = args[0]
+
+    return Validate.isMovableOrgUnit(orgUnit)
+  },
+
+  getMessage: common.getMessage
+}

--- a/frontend/src/vee.js
+++ b/frontend/src/vee.js
@@ -16,6 +16,7 @@ import Employee from './validators/Employee'
 import ExistingAssociations from './validators/ExistingAssociations'
 import DateInRange from './validators/DateInRange'
 import OrgUnit from './validators/OrgUnit'
+import MovableOrgUnit from "./validators/MovableOrgUnit";
 
 /**
  * See configuration options here:
@@ -46,6 +47,7 @@ Validator.extend('cpr', Cpr)
 Validator.extend('employee', Employee)
 Validator.extend('existing_associations', ExistingAssociations)
 Validator.extend('date_in_range', DateInRange)
+Validator.extend('movable_org_unit', MovableOrgUnit)
 Validator.extend('orgunit', OrgUnit)
 
 Vue.use(VeeValidate, veeConfig)

--- a/frontend/src/views/organisation/workflows/MoOrganisationUnitMove.vue
+++ b/frontend/src/views/organisation/workflows/MoOrganisationUnitMove.vue
@@ -48,6 +48,7 @@
         :label="$t('input_fields.select_new_super_unit')"
         :date="move.data.validity.from"
         :validity="validity"
+        :disabled-unit="original"
         :extra-validations="parentValidations"
         required
       />

--- a/frontend/src/views/organisation/workflows/MoOrganisationUnitMove.vue
+++ b/frontend/src/views/organisation/workflows/MoOrganisationUnitMove.vue
@@ -26,6 +26,7 @@
             :label="$t('input_fields.select_unit')"
             :date="move.data.validity.from"
             :validity="validity"
+            :extra-validations="unitValidations"
             required
           />
         </div>
@@ -108,6 +109,12 @@ export default {
     validity () {
       return {
         'from': this.move.data.validity.from
+      }
+    },
+
+    unitValidations () {
+      return {
+        movable_org_unit: [this.original]
       }
     },
 

--- a/frontend/src/views/organisation/workflows/MoOrganisationUnitMove.vue
+++ b/frontend/src/views/organisation/workflows/MoOrganisationUnitMove.vue
@@ -36,7 +36,7 @@
           <input
             type="text"
             class="form-control"
-            :value="parentUnit"
+            :value="original && original.parent && original.parent.name"
             disabled
           >
         </div>
@@ -44,7 +44,7 @@
 
       <mo-organisation-unit-picker
         class="parentUnit"
-        v-model="move.data.parent"
+        v-model="parent"
         :label="$t('input_fields.select_new_super_unit')"
         :date="move.data.validity.from"
         :validity="validity"
@@ -92,11 +92,14 @@ export default {
        * The move, parentUnit, uuid, original, isLoading, backendValidationError component value.
        * Used to detect changes and restore the value.
        */
-      parentUnit: '',
       original: null,
+      parent: null,
       move: {
         type: 'org_unit',
         data: {
+          parent: {
+            uuid: ''
+          },
           uuid: '',
           validity: {}
         }
@@ -124,21 +127,17 @@ export default {
         candidate_parent_org_unit: [this.original, this.move.data.parent, this.validity]
       }
     }
-
   },
 
   watch: {
     /**
      * If original exist show its parent.
      */
-    original: {
-      handler (newVal) {
-        if (this.original) {
-          this.move.data.uuid = newVal.uuid
-          return this.getCurrentUnit(newVal.uuid)
-        }
-      },
-      deep: true
+    "original.uuid" (newVal) {
+      this.move.data.uuid = newVal
+    },
+    "parent.uuid" (newVal) {
+      this.move.data.parent.uuid = newVal
     }
   },
 
@@ -172,18 +171,6 @@ export default {
       } else {
         this.$validator.validateAll()
       }
-    },
-
-    /**
-     * Get current organisation unit.
-     */
-    getCurrentUnit (unitUuid) {
-      let vm = this
-      if (!unitUuid) return
-      OrganisationUnit.get(unitUuid)
-        .then(response => {
-          vm.parentUnit = response.parent ? response.parent.name : ''
-        })
     }
   }
 }


### PR DESCRIPTION
This fixes a race condition where we ran the validators before emitting the event that effected the change to the validated field. As a result, the dialog would always validate the _previous_ value of the field. In most cases, you wouldn't notice this, but you would for the initial input, where there was no previous value.

Since this was rather hard to track down, I fixed a few other bugs while at it. I made sure that we write the error above root units below the actual root unit, and applied a minor change to prevent moving a selecting the same source and destination.

https://redmine.magenta-aps.dk/issues/29570

- [ ] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [ ] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [x] Changes have been made to the UI
    - [x] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->

---

![Screenshot 2019-08-14 at 15 32 04](https://user-images.githubusercontent.com/59300/63025112-d3e08280-bea8-11e9-9a63-008ba42c68c5.png)
![Screenshot 2019-08-14 at 15 32 34](https://user-images.githubusercontent.com/59300/63025125-d7740980-bea8-11e9-9ebf-266e69e09fd8.png)
