### PR TITLE
Streamline how various request handlers use the 'org' parameter

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,6 +11,8 @@ Bug fixes
 
 * #22316: Ensure update payloads sent to LoRa satisfy validation
   requirements
+* #31663: ``org`` is now correctly an optional (deprecated) parameter on
+  creation of various objects
 
 Internal changes
 ----------------

--- a/backend/mora/service/address.py
+++ b/backend/mora/service/address.py
@@ -17,6 +17,7 @@ import uuid
 from . import employee
 from . import facet
 from . import handlers
+from . import org
 from . import orgunit
 from .address_handler import base
 from .validation import validator
@@ -227,7 +228,8 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
 
         valid_from, valid_to = util.get_validities(req)
 
-        orgid = util.get_mapping_uuid(req, mapping.ORG, required=True)
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
         address_type_uuid = util.get_mapping_uuid(req, mapping.ADDRESS_TYPE,
                                                   required=True)
@@ -261,7 +263,7 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
             funktionstype=address_type_uuid,
             adresser=[handler.get_lora_address()],
             tilknyttedebrugere=[employee_uuid] if employee_uuid else [],
-            tilknyttedeorganisationer=[orgid],
+            tilknyttedeorganisationer=[org_uuid],
             tilknyttedeenheder=[org_unit_uuid] if org_unit_uuid else [],
             tilknyttedefunktioner=[manager_uuid] if manager_uuid else [],
             opgaver=handler.get_lora_properties(),

--- a/backend/mora/service/association.py
+++ b/backend/mora/service/association.py
@@ -16,9 +16,9 @@ This section describes how to interact with employee associations.
 import uuid
 
 from . import handlers
+from . import org
 from .validation import validator
 from .. import common
-from .. import exceptions
 from .. import lora
 from .. import mapping
 from .. import util
@@ -29,8 +29,6 @@ class AssociationRequestHandler(handlers.OrgFunkRequestHandler):
     function_key = mapping.ASSOCIATION_KEY
 
     def prepare_create(self, req):
-        c = lora.Connector()
-
         org_unit = util.checked_get(req, mapping.ORG_UNIT,
                                     {}, required=True)
         org_unit_uuid = util.get_uuid(org_unit, required=True)
@@ -38,14 +36,9 @@ class AssociationRequestHandler(handlers.OrgFunkRequestHandler):
         employee = util.checked_get(req, mapping.PERSON, {}, required=True)
         employee_uuid = util.get_uuid(employee, required=True)
 
-        org_unit_obj = c.organisationenhed.get(org_unit_uuid)
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
-        if not org_unit_obj:
-            exceptions.ErrorCodes.E_ORG_UNIT_NOT_FOUND(
-                org_unit_uuid=org_unit_uuid,
-            )
-
-        org_uuid = org_unit_obj['relationer']['tilhoerer'][0]['uuid']
         association_type_uuid = util.get_mapping_uuid(
             req,
             mapping.ASSOCIATION_TYPE,

--- a/backend/mora/service/employee.py
+++ b/backend/mora/service/employee.py
@@ -79,9 +79,9 @@ class EmployeeRequestHandler(handlers.RequestHandler):
             {},
             required=False
         )
-        org_uuid_specified = util.get_mapping_uuid(req, mapping.ORG,
-                                                   required=True)
-        org_uuid = org.get_configured_organisation(org_uuid_specified)["uuid"]
+
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
         cpr = util.checked_get(req, mapping.CPR_NO, "", required=False)
         userid = util.get_uuid(req, required=False) or str(uuid.uuid4())

--- a/backend/mora/service/engagement.py
+++ b/backend/mora/service/engagement.py
@@ -17,6 +17,7 @@ employees and organisational units.
 import uuid
 
 from . import handlers
+from . import org
 from .validation import validator
 from .. import common
 from .. import lora
@@ -29,8 +30,6 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
     function_key = mapping.ENGAGEMENT_KEY
 
     def prepare_create(self, req):
-        c = lora.Connector()
-
         org_unit = util.checked_get(req, mapping.ORG_UNIT,
                                     {}, required=True)
         org_unit_uuid = util.get_uuid(org_unit, required=True)
@@ -55,9 +54,9 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
                 self.function_key, valid_from, valid_to, employee_uuid,
             )
 
-        org_unit_obj = c.organisationenhed.get(org_unit_uuid)
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
-        org_uuid = org_unit_obj['relationer']['tilhoerer'][0]['uuid']
         job_function_uuid = util.get_mapping_uuid(req,
                                                   mapping.JOB_FUNCTION)
         engagement_type_uuid = util.get_mapping_uuid(req,

--- a/backend/mora/service/itsystem.py
+++ b/backend/mora/service/itsystem.py
@@ -21,6 +21,7 @@ import uuid
 import flask
 
 from . import handlers
+from . import org
 from .validation import validator
 from .. import common
 from .. import exceptions
@@ -45,15 +46,14 @@ class ItsystemRequestHandler(handlers.OrgFunkRequestHandler):
         if not system:
             exceptions.ErrorCodes.E_NOT_FOUND()
 
-        # Get org unit uuid for validation purposes
-        org_unit = util.checked_get(req, mapping.ORG_UNIT,
-                                    {}, required=False)
+        org_unit = util.checked_get(req, mapping.ORG_UNIT, {}, required=False)
         org_unit_uuid = util.get_uuid(org_unit, required=False)
 
         employee = util.checked_get(req, mapping.PERSON, {}, required=False)
         employee_uuid = util.get_uuid(employee, required=False)
 
-        org_uuid = system['relationer']['tilhoerer'][0]['uuid']
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
         valid_from, valid_to = util.get_validities(req)
 

--- a/backend/mora/service/leave.py
+++ b/backend/mora/service/leave.py
@@ -16,6 +16,7 @@ This section describes how to interact with employee leave.
 import uuid
 
 from . import handlers
+from . import org
 from .validation import validator
 from .. import common
 from .. import exceptions
@@ -29,17 +30,13 @@ class LeaveRequestHandler(handlers.OrgFunkRequestHandler):
     function_key = mapping.LEAVE_KEY
 
     def prepare_create(self, req):
-        c = lora.Connector()
 
         employee = util.checked_get(req, mapping.PERSON, {}, required=True)
         employee_uuid = util.get_uuid(employee, required=True)
 
-        userobj = c.bruger.get(employee_uuid)
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
-        if not userobj:
-            exceptions.ErrorCodes.E_USER_NOT_FOUND(employee_uuid=employee_uuid)
-
-        org_uuid = userobj['relationer']['tilhoerer'][0]['uuid']
         leave_type_uuid = util.get_mapping_uuid(req, mapping.LEAVE_TYPE,
                                                 required=True)
         valid_from, valid_to = util.get_validities(req)

--- a/backend/mora/service/manager.py
+++ b/backend/mora/service/manager.py
@@ -12,15 +12,15 @@
 This section describes how to interact with employee manager roles.
 
 """
-import uuid
 import operator
-import flask
+import uuid
 
 from . import address
-from . import handlers
-from . import orgunit
-from . import facet
 from . import employee
+from . import facet
+from . import handlers
+from . import org
+from . import orgunit
 from .validation import validator
 from .. import common
 from .. import lora
@@ -128,8 +128,6 @@ class ManagerRequestHandler(handlers.OrgFunkReadingRequestHandler):
     def prepare_create(self, req):
         """ To create a vacant manager postition, set employee_uuid to None
         and set a value org_unit_uuid """
-        c = lora.Connector()
-
         org_unit = util.checked_get(req, mapping.ORG_UNIT,
                                     {}, required=True)
         org_unit_uuid = util.get_uuid(org_unit, required=True)
@@ -137,13 +135,10 @@ class ManagerRequestHandler(handlers.OrgFunkReadingRequestHandler):
         employee = util.checked_get(req, mapping.PERSON, {}, required=False)
         employee_uuid = util.get_uuid(employee, required=False)
 
-        # TODO: Figure out what to do with this
         valid_from, valid_to = util.get_validities(req)
 
-        org_uuid = (
-            c.organisationenhed.get(org_unit_uuid)
-            ['relationer']['tilhoerer'][0]['uuid']
-        )
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
         manager_type_uuid = util.get_mapping_uuid(req, mapping.MANAGER_TYPE)
         manager_level_uuid = util.get_mapping_uuid(req, mapping.MANAGER_LEVEL)

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -107,8 +107,6 @@ class OrgUnitRequestHandler(handlers.ReadingRequestHandler):
         ])
 
     def prepare_create(self, req):
-        c = lora.Connector()
-
         req = flask.request.get_json()
 
         name = util.checked_get(req, mapping.NAME, "", required=True)
@@ -126,13 +124,6 @@ class OrgUnitRequestHandler(handlers.ReadingRequestHandler):
         parent_uuid = util.get_mapping_uuid(req, mapping.PARENT, required=True)
 
         org_uuid = org.get_configured_organisation()["uuid"]
-        organisationenhed_get = c.organisationenhed.get(parent_uuid)
-
-        if not (organisationenhed_get or parent_uuid == org_uuid):
-            exceptions.ErrorCodes.V_PARENT_NOT_FOUND(
-                parent_uuid=parent_uuid,
-                org_unit_uuid=unitid,
-            )
 
         org_unit_type_uuid = util.get_mapping_uuid(req, mapping.ORG_UNIT_TYPE,
                                                    required=False)

--- a/backend/mora/service/role.py
+++ b/backend/mora/service/role.py
@@ -17,6 +17,7 @@ This section describes how to interact with employee roles.
 import uuid
 
 from . import handlers
+from . import org
 from .validation import validator
 from .. import common
 from .. import exceptions
@@ -30,8 +31,6 @@ class RoleRequestHandler(handlers.OrgFunkRequestHandler):
     function_key = mapping.ROLE_KEY
 
     def prepare_create(self, req):
-        c = lora.Connector()
-
         org_unit = util.checked_get(req, mapping.ORG_UNIT,
                                     {}, required=True)
         org_unit_uuid = util.get_uuid(org_unit, required=True)
@@ -47,10 +46,8 @@ class RoleRequestHandler(handlers.OrgFunkRequestHandler):
         validator.is_date_range_in_employee_range(employee, valid_from,
                                                   valid_to)
 
-        org_uuid = (
-            c.organisationenhed.get(org_unit_uuid)
-            ['relationer']['tilhoerer'][0]['uuid']
-        )
+        org_uuid = org.get_configured_organisation(
+            util.get_mapping_uuid(req, mapping.ORG, required=False))["uuid"]
 
         role_type_uuid = util.get_mapping_uuid(req, mapping.ROLE_TYPE,
                                                required=True)

--- a/backend/tests/test_integration_address.py
+++ b/backend/tests/test_integration_address.py
@@ -66,9 +66,6 @@ class Writing(util.LoRATestCase):
                     "type": "address",
                     "address_type": ean_class,
                     "value": '1234567890',
-                    "org": {
-                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
-                    },
                     "validity": {
                         "from": "2013-01-01",
                         "to": None,
@@ -102,9 +99,6 @@ class Writing(util.LoRATestCase):
                     "org_unit": {
                         'uuid': unitid,
                     },
-                    "org": {
-                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
-                    },
                     "validity": {
                         "from": "2013-01-01",
                         "to": None,
@@ -132,9 +126,6 @@ class Writing(util.LoRATestCase):
                     "type": "address",
                     "address_type": email_class,
                     "org_unit": {"uuid": unitid},
-                    "org": {
-                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
-                    },
                     # NB: no value
                     "validity": {
                         "from": "2017-01-01",
@@ -164,9 +155,6 @@ class Writing(util.LoRATestCase):
                     # NB: no type!
                     "address_type": None,
                     "value": "hallo@exmaple.com",
-                    "org": {
-                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
-                    },
                     "org_unit": {"uuid": unitid},
                     "validity": {
                         "from": "2013-01-01",
@@ -195,9 +183,6 @@ class Writing(util.LoRATestCase):
                 "address_type": address_class,
                 "value": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
                 "org_unit": {"uuid": nothingid},
-                "org": {
-                    'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
-                },
                 "validity": {
                     "from": "2013-01-01",
                     "to": None,
@@ -223,9 +208,6 @@ class Writing(util.LoRATestCase):
                 "address_type": address_class,
                 "value": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
                 "person": {"uuid": nothingid},
-                "org": {
-                    'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
-                },
                 "validity": {
                     "from": "2013-01-01",
                     "to": None,
@@ -271,9 +253,6 @@ class Writing(util.LoRATestCase):
                     "person": {"uuid": "53181ed2-f1de-4c4a-a8fd-ab358c2c454a"},
                     "validity": {
                         "from": "2017-01-02",
-                    },
-                    "org": {
-                        'uuid': "456362c4-0ee4-4e5e-a72c-751239745e62"
                     },
                 }
             ]
@@ -337,9 +316,6 @@ class Writing(util.LoRATestCase):
                     'value': 'root@example.com',
                     "org_unit": {
                         "uuid": unitid
-                    },
-                    "org": {
-                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
                     },
                     "validity": {
                         "from": "2017-01-02",
@@ -444,9 +420,6 @@ class Writing(util.LoRATestCase):
                     'value': 'root@example.com',
                     "person": {
                         "uuid": employee_id
-                    },
-                    "org": {
-                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
                     },
                     "validity": {
                         "from": "2017-01-02",
@@ -589,9 +562,6 @@ class Writing(util.LoRATestCase):
             json={
                 "name": "Torkild Testperson",
                 "cpr_no": "0101501234",
-                "org": {
-                    'uuid': "456362c4-0ee4-4e5e-a72c-751239745e62"
-                },
                 "details": [
                     {
                         "type": "address",
@@ -601,9 +571,6 @@ class Writing(util.LoRATestCase):
                         'value': 'root@example.com',
                         "validity": {
                             "from": "2017-01-02",
-                        },
-                        "org": {
-                            'uuid': "456362c4-0ee4-4e5e-a72c-751239745e62"
                         },
                     },
                 ]
@@ -734,9 +701,6 @@ class Writing(util.LoRATestCase):
                     "validity": {
                         "from": "2017-01-02",
                     },
-                    "org": {
-                        'uuid': "456362c4-0ee4-4e5e-a72c-751239745e62"
-                    },
                 }],
             }],
             amqp_topics={
@@ -854,9 +818,6 @@ class Writing(util.LoRATestCase):
                         'value': 'root@example.com',
                         "validity": {
                             "from": "2017-01-02",
-                        },
-                        "org": {
-                            'uuid': "456362c4-0ee4-4e5e-a72c-751239745e62"
                         },
                     },
                 ]

--- a/backend/tests/test_integration_org_unit.py
+++ b/backend/tests/test_integration_org_unit.py
@@ -1354,13 +1354,11 @@ class Tests(util.LoRATestCase):
         self.assertRequestResponse(
             '/service/ou/create',
             {
-                'description':
-                'Corresponding parent unit or organisation not found.',
+                'description': 'Org unit not found.',
                 'error': True,
-                'error_key': 'V_PARENT_NOT_FOUND',
-                'org_unit_uuid': 'ec93e37e-774e-40b4-953c-05ca41b80372',
-                'parent_uuid': '00000000-0000-0000-0000-000000000000',
-                'status': 404,
+                'error_key': 'E_ORG_UNIT_NOT_FOUND',
+                'org_unit_uuid': '00000000-0000-0000-0000-000000000000',
+                'status': 404
             },
             json=payload,
             status_code=404,


### PR DESCRIPTION
All handlers now take 'org' as an optional parameter, which is
alternatively looked up from the cache, so we never fetch from LoRa

https://redmine.magenta-aps.dk/issues/31661

- [ ] This is a trivial change (and the rest of the list can be ignored)

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [x] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [ ] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
