### PR TITLE
Prevent user from terminating managers before they are active.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,6 +20,8 @@ Bug fixes
 * #31851: Creating relations for org units now correctly takes the org unit
   validity into account when limiting the date pickers.
 * #29604: Redirect to the page of a newly created org unit
+* #29548: We now prevent the user from terminating managers (and other
+  relations), before they are active.
 
 Internal changes
 ----------------

--- a/frontend/src/components/MoEntryTerminateModal.vue
+++ b/frontend/src/components/MoEntryTerminateModal.vue
@@ -104,8 +104,10 @@ export default {
      * Check if the organisation date are valid.
      */
     validDates () {
+      let today = moment().format('YYYY-MM-DD')
+
       return {
-        from: moment().format('YYYY-MM-DD'),
+        from: this.content.validity.from < today ? today : this.content.validity.from,
         to: this.content.validity.to
       }
     }
@@ -143,6 +145,7 @@ export default {
           })
           .catch(err => {
             this.backendValidationError = err.response.data
+            this.isLoading = false
           })
       } else {
         this.$validator.validateAll()


### PR DESCRIPTION
The modal now also correctly responds to errors from the backend.

https://redmine.magenta-aps.dk/issues/29548

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [x] Tests have been written/updated for my change
- [ ] ~The documentation has been updated~ - nothing to update
    - [ ] ~The documentation builds without warnings or errors~
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [x] Changes have been made to the UI
    - [ ] ~Screenshots of relevant changes to UI added to PR~ - nothing to screenshot, really
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
