### PR TITLE
Remove user_key from creation and edit dialogs in UI

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,6 +8,7 @@ New features
 * #30983: Make time planning field on org units hidden based on configuration
 * #29129: Org unit location delimiter is now backslash
 * #29417: Prevent users from editing inherited managers
+* #30597: Removed user_key from org unit dialogs in UI
 
 Bug fixes
 ---------
@@ -30,7 +31,7 @@ Internal changes
 * #29626: DAR address objects can now be inserted regardless of whether DAR is
   up, using ``force``. DAR address objects in LoRa no longer include the
   'pretty' address, to simplify saving the object.
-* #31732: Adjusted table and removed org_unit and engagement-ID from engagement 
+* #31732: Adjusted table and removed org_unit and engagement-ID from engagement
   and associatied tabs for organisation.
 
 

--- a/frontend/src/components/MoEntry/MoOrganisationUnitEntry.vue
+++ b/frontend/src/components/MoEntry/MoOrganisationUnitEntry.vue
@@ -13,12 +13,6 @@
         required
       />
 
-      <mo-input-text
-        :label="$t('input_fields.org_unit_user_key')"
-        :placeholder="$t('input_fields.org_unit_user_key_placeholder')"
-        v-model="entry.user_key"
-      />
-
       <mo-facet-picker
         facet="org_unit_type"
         v-model="entry.org_unit_type"
@@ -98,9 +92,6 @@ export default {
      */
     entry: {
       handler (newVal) {
-        if (newVal.user_key === undefined || newVal.user_key === ""){
-          newVal.user_key = null; 
-        }
         this.$emit('input', newVal)
       },
       deep: true

--- a/frontend/src/locales/da/input_fields.json
+++ b/frontend/src/locales/da/input_fields.json
@@ -17,8 +17,6 @@
   "name": "Navn",
   "new_name": "Nyt navn",
   "org_unit_type": "@:shared.org_unit_type",
-  "org_unit_user_key": "Enhedsnummer",
-  "org_unit_user_key_placeholder": "Udfyld eller auto",
   "primary": "@:shared.primary",
   "primary_association": "Primær tilknytning",
   "primary_engagement": "Primær engagement",


### PR DESCRIPTION
https://redmine.magenta-aps.dk/issues/30597

This PR essentially undos #397 

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [x] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
