### PR TITLE
Prevent user from editing user key on org units

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,6 +8,7 @@ New features
 * #30983: Make time planning field on org units hidden based on configuration
 * #29129: Org unit location delimiter is now backslash
 * #29417: Prevent users from editing inherited managers
+* #32048: Prevent users from editing org unit user keys
 
 Bug fixes
 ---------

--- a/frontend/src/components/MoEntry/MoEntryBase.js
+++ b/frontend/src/components/MoEntry/MoEntryBase.js
@@ -28,7 +28,16 @@ export default Vue.extend({
      * @default null
      * @type {Object}
      */
-    disabledDates: Object
+    disabledDates: Object,
+
+    /**
+     * Whether we are using the entry for editing the entry
+     * true if editing, false if creating
+     */
+    isEdit: {
+      type: Boolean,
+      default: false
+    }
   },
 
   data () {

--- a/frontend/src/components/MoEntry/MoOrganisationUnitEntry.vue
+++ b/frontend/src/components/MoEntry/MoOrganisationUnitEntry.vue
@@ -13,7 +13,7 @@
         required
       />
 
-      <mo-input-text
+      <mo-input-text v-if="showUserKey"
         :label="$t('input_fields.org_unit_user_key')"
         :placeholder="$t('input_fields.org_unit_user_key_placeholder')"
         v-model="entry.user_key"
@@ -89,6 +89,9 @@ export default {
         return showTimePlanning
       }
       return false
+    },
+    showUserKey () {
+      return !this.isEdit
     }
   },
 
@@ -99,7 +102,7 @@ export default {
     entry: {
       handler (newVal) {
         if (newVal.user_key === undefined || newVal.user_key === ""){
-          newVal.user_key = null; 
+          newVal.user_key = null;
         }
         this.$emit('input', newVal)
       },

--- a/frontend/src/components/MoEntryEditModal.vue
+++ b/frontend/src/components/MoEntryEditModal.vue
@@ -23,6 +23,7 @@
         :hide-org-picker="hideOrgPicker"
         :hide-employee-picker="hideEmployeePicker"
         :disabled-dates="disabledDates"
+        :is-edit="true"
       />
 
       <div class="alert alert-danger" v-if="backendValidationMessage">


### PR DESCRIPTION
Adding the user key when creating org units is still possible

https://redmine.magenta-aps.dk/issues/32048

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [ ] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [ ] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
