### PR TITLE
32476: Re-enable functionality to edit the past

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -5,6 +5,7 @@ New features
 ------------
 
 * #29760: Best practises updated concerning OS2Sync integration
+* #32467: We now once again allow performing edits in the past
 
 Bug fixes
 ---------

--- a/backend/mora/exceptions.py
+++ b/backend/mora/exceptions.py
@@ -80,8 +80,6 @@ class ErrorCodes(Enum):
         404, "Corresponding parent unit or organisation not found."
     V_DUPLICATED_RESPONSIBILITY = \
         400, "Manager has the same responsibility more than once."
-    V_CHANGING_THE_PAST = \
-        400, "Cannot perform changes before current date"
     V_INVALID_ADDRESS_DAR = 400, "Invalid address"
     V_INVALID_ADDRESS_EAN = 400, "Invalid EAN"
     V_INVALID_ADDRESS_EMAIL = 400, "Invalid email"

--- a/backend/mora/service/address.py
+++ b/backend/mora/service/address.py
@@ -9,10 +9,10 @@
 import collections
 import json
 import re
+import uuid
 
 import flask
 import requests
-import uuid
 
 from . import employee
 from . import facet
@@ -296,8 +296,6 @@ class AddressRequestHandler(handlers.OrgFunkReadingRequestHandler):
 
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
-
-        validator.is_edit_from_date_before_today(new_from)
 
         payload = {
             'note': 'Rediger Adresse',

--- a/backend/mora/service/association.py
+++ b/backend/mora/service/association.py
@@ -22,7 +22,6 @@ from .. import common
 from .. import lora
 from .. import mapping
 from .. import util
-from ..triggers import Trigger
 
 
 class AssociationRequestHandler(handlers.OrgFunkRequestHandler):
@@ -94,8 +93,6 @@ class AssociationRequestHandler(handlers.OrgFunkRequestHandler):
 
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
-
-        validator.is_edit_from_date_before_today(new_from)
 
         # Get org unit uuid for validation purposes
         org_unit = mapping.ASSOCIATED_ORG_UNIT_FIELD(original)[0]

--- a/backend/mora/service/employee.py
+++ b/backend/mora/service/employee.py
@@ -135,8 +135,6 @@ class EmployeeRequestHandler(handlers.RequestHandler):
         original = c.bruger.get(uuid=userid)
         new_from, new_to = util.get_validities(data)
 
-        validator.is_edit_from_date_before_today(new_from)
-
         payload = dict()
         if original_data:
             # We are performing an update
@@ -463,8 +461,6 @@ def terminate_employee(employee_uuid):
     """
     request = flask.request.get_json()
     date = util.get_valid_to(request)
-
-    validator.is_edit_from_date_before_today(date)
 
     c = lora.Connector(effective_date=date, virkningtil='infinity')
 

--- a/backend/mora/service/engagement.py
+++ b/backend/mora/service/engagement.py
@@ -102,8 +102,6 @@ class EngagementRequestHandler(handlers.OrgFunkRequestHandler):
         data = util.checked_get(req, 'data', {}, required=True)
         new_from, new_to = util.get_validities(data)
 
-        validator.is_edit_from_date_before_today(new_from)
-
         try:
             exts = mapping.ORG_FUNK_UDVIDELSER_FIELD(original)[-1].copy()
         except (TypeError, LookupError):

--- a/backend/mora/service/handlers.py
+++ b/backend/mora/service/handlers.py
@@ -14,17 +14,16 @@ handlers for the various detail types.
 import abc
 import inspect
 import typing
+
 import flask
 
-from .validation import validator
 from .. import common
 from .. import exceptions
 from .. import lora
 from .. import mapping
 from .. import util
-from ..triggers import Trigger
 from ..mapping import RequestType
-
+from ..triggers import Trigger
 
 # The handler mappings are populated by each individual active
 # RequestHandler
@@ -197,8 +196,6 @@ class OrgFunkRequestHandler(RequestHandler):
     def prepare_terminate(self, request: dict):
         self.uuid = util.get_uuid(request)
         date = util.get_valid_to(request, required=True)
-
-        validator.is_edit_from_date_before_today(date)
 
         original = (
             lora.Connector(effective_date=date)

--- a/backend/mora/service/itsystem.py
+++ b/backend/mora/service/itsystem.py
@@ -106,8 +106,6 @@ class ItsystemRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
-        validator.is_edit_from_date_before_today(new_from)
-
         payload = {
             'note': 'Rediger IT-system',
         }

--- a/backend/mora/service/leave.py
+++ b/backend/mora/service/leave.py
@@ -19,7 +19,6 @@ from . import handlers
 from . import org
 from .validation import validator
 from .. import common
-from .. import exceptions
 from .. import lora
 from .. import mapping
 from .. import util
@@ -75,8 +74,6 @@ class LeaveRequestHandler(handlers.OrgFunkRequestHandler):
 
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
-
-        validator.is_edit_from_date_before_today(new_from)
 
         payload = dict()
         payload['note'] = 'Rediger orlov'

--- a/backend/mora/service/manager.py
+++ b/backend/mora/service/manager.py
@@ -233,8 +233,6 @@ class ManagerRequestHandler(handlers.OrgFunkReadingRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
-        validator.is_edit_from_date_before_today(new_from)
-
         # Get org unit uuid for validation purposes
         org_unit = mapping.ASSOCIATED_ORG_UNIT_FIELD(original)[0]
 

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -27,10 +27,10 @@ import uuid
 
 import flask
 
+from . import configuration_options
 from . import facet
 from . import handlers
 from . import org
-from . import configuration_options
 from .validation import validator
 from .. import common
 from .. import exceptions
@@ -183,8 +183,6 @@ class OrgUnitRequestHandler(handlers.ReadingRequestHandler):
             exceptions.ErrorCodes.E_ORG_UNIT_NOT_FOUND(org_unit_uuid=unitid)
 
         new_from, new_to = util.get_validities(data)
-
-        validator.is_edit_from_date_before_today(new_from)
 
         clamp = util.checked_get(data, 'clamp', False)
 

--- a/backend/mora/service/related.py
+++ b/backend/mora/service/related.py
@@ -17,7 +17,6 @@ This section describes how to interact with related units.
 import flask
 
 from . import handlers
-from .validation import validator
 from .. import common
 from .. import exceptions
 from .. import lora
@@ -113,8 +112,6 @@ def map_org_units(origin):
     c = lora.Connector(effective_date=date)
     destinations = set(util.checked_get(req, 'destination', [],
                                         required=True))
-
-    validator.is_edit_from_date_before_today(date)
 
     wanted_units = {origin} | destinations
     units = dict(c.organisationenhed.get_all(uuid=sorted(wanted_units)))

--- a/backend/mora/service/role.py
+++ b/backend/mora/service/role.py
@@ -86,8 +86,6 @@ class RoleRequestHandler(handlers.OrgFunkRequestHandler):
         data = req.get('data')
         new_from, new_to = util.get_validities(data)
 
-        validator.is_edit_from_date_before_today(new_from)
-
         # Get org unit uuid for validation purposes
         org_unit = mapping.ASSOCIATED_ORG_UNIT_FIELD(original)[0]
 

--- a/backend/mora/service/validation/validator.py
+++ b/backend/mora/service/validation/validator.py
@@ -386,19 +386,6 @@ def does_employee_have_existing_primary_function(function_key,
 
 
 @forceable
-def is_edit_from_date_before_today(from_date: datetime.datetime):
-    """Check if a given edit date is before today. If so, raise exception"""
-    today = datetime.datetime.combine(
-        datetime.date.today(),
-        datetime.time(0, 0, 0, 0, from_date.tzinfo)
-    )
-    if from_date < today:
-        raise exceptions.ErrorCodes.V_CHANGING_THE_PAST(
-            date=util.to_iso_time(from_date)
-        )
-
-
-@forceable
 def does_employee_with_cpr_already_exist(cpr, valid_from, valid_to, org_uuid,
                                          allowed_user_id=None):
     """

--- a/backend/tests/test_integration_association.py
+++ b/backend/tests/test_integration_association.py
@@ -2259,38 +2259,6 @@ class Tests(util.LoRATestCase):
             },
         )
 
-    def test_edit_association_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        association_uuid = 'c2153d5d-4a2b-492d-a18c-c498f7bb6221'
-
-        req = [{
-            "type": "association",
-            "uuid": association_uuid,
-            "data": {
-                "association_type": {
-                    'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
-                },
-                "validity": {
-                    "from": "2000-01-01",
-                },
-            },
-        }]
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2000-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400,
-        )
-
     def test_terminate_association_via_user(self):
         self.load_sample_structures()
 
@@ -2498,13 +2466,17 @@ class AddressTests(util.LoRATestCase):
         associationid = 'c2153d5d-4a2b-492d-a18c-c498f7bb6221'
 
         self.assertRequestFails(
-            '/service/details/terminate', 400,
+            '/service/details/terminate', 200,
             json={
                 "type": "association",
                 "uuid": associationid,
                 "validity": {
                     "to": "2017-11-30"
                 }
+            },
+            amqp_topics={
+                'employee.association.delete': 1,
+                'org_unit.association.delete': 1,
             },
         )
 

--- a/backend/tests/test_integration_employee.py
+++ b/backend/tests/test_integration_employee.py
@@ -849,34 +849,3 @@ class Tests(util.LoRATestCase):
             },
             amqp_topics={'employee.employee.update': 1},
         )
-
-    def test_edit_employee_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        userid = "6ee24785-ee9a-4502-81c2-7697009c9053"
-
-        req = [{
-            "type": "employee",
-            "original": None,
-            "data": {
-                "validity": {
-                    "from": "2000-01-01",
-                },
-                "cpr_no": "0101010101",
-                "name": "Test 1 Employee",
-            },
-            "uuid": userid
-        }]
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2000-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400)

--- a/backend/tests/test_integration_engagement.py
+++ b/backend/tests/test_integration_engagement.py
@@ -7,10 +7,10 @@
 #
 
 import copy
-import uuid
 
 import freezegun
 import notsouid
+import uuid
 
 from mora import lora
 from tests import util
@@ -1660,35 +1660,6 @@ class Tests(util.LoRATestCase):
         actual_engagement = c.organisationfunktion.get(engagement_uuid)
 
         self.assertRegistrationsEqual(expected_engagement, actual_engagement)
-
-    def test_edit_engagement_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        engagement_uuid = 'd000591f-8705-4324-897a-075e3623f37b'
-
-        req = [{
-            "type": "engagement",
-            "uuid": engagement_uuid,
-            "data": {
-                "org_unit": {'uuid': "b688513d-11f7-4efc-b679-ab082a2055d0"},
-                "validity": {
-                    "from": "2000-01-01",
-                }
-            },
-        }]
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2000-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400)
 
     def test_terminate_engagement(self):
         self.load_sample_structures()

--- a/backend/tests/test_integration_itsystem.py
+++ b/backend/tests/test_integration_itsystem.py
@@ -8,9 +8,9 @@
 
 import copy
 import logging
-import pytest
 
 import freezegun
+import pytest
 
 from mora import lora
 from tests import util
@@ -661,37 +661,6 @@ class Writing(util.LoRATestCase):
             [future],
             amqp_topics={'org_unit.it.update': 1},
         )
-
-    def test_edit_itsystem_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        function_id = "cd4dcccb-5bf7-4c6b-9e1a-f6ebb193e276"
-
-        req = {
-            "type": "it",
-            "uuid": function_id,
-            "data": {
-                "itsystem": {
-                    "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
-                },
-                "validity": {
-                    "from": "2000-01-01",
-                }
-            }
-        }
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2000-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400)
 
     @freezegun.freeze_time('2017-06-22', tz_offset=2)
     def test_edit_move_itsystem(self):

--- a/backend/tests/test_integration_leave.py
+++ b/backend/tests/test_integration_leave.py
@@ -5,9 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-from unittest.mock import patch
-
 import freezegun
+from unittest.mock import patch
 
 from mora import lora
 from tests import util
@@ -686,38 +685,6 @@ class Tests(util.LoRATestCase):
             json=req,
             status_code=400
         )
-
-    @freezegun.freeze_time('2020-01-01')
-    def test_edit_leave_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        leave_uuid = 'b807628c-030c-4f5f-a438-de41c1f26ba5'
-
-        req = [{
-            "type": "leave",
-            "uuid": leave_uuid,
-            "data": {
-                "leave_type": {
-                    'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
-                },
-                "validity": {
-                    "from": "2018-01-01",
-                },
-            },
-        }]
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2018-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400)
 
     def test_terminate_leave(self):
         self.load_sample_structures()

--- a/backend/tests/test_integration_manager.py
+++ b/backend/tests/test_integration_manager.py
@@ -9,10 +9,9 @@
 import copy
 import unittest
 
-from unittest.mock import patch
-
 import freezegun
 import notsouid
+from unittest.mock import patch
 
 from mora import lora
 from mora import util as mora_util
@@ -2598,38 +2597,6 @@ class Tests(util.LoRATestCase):
                 'org_unit.manager.update': 1,
                 'employee.manager.update': 1,
             },
-        )
-
-    def test_edit_manager_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        manager_uuid = '05609702-977f-4869-9fb4-50ad74c6999a'
-
-        req = {
-            "type": "manager",
-            "uuid": manager_uuid,
-            "data": {
-                "manager_type": {
-                    'uuid': "ca76a441-6226-404f-88a9-31e02e420e52"
-                },
-                "validity": {
-                    "from": "2000-01-01",
-                },
-            },
-        }
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2000-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400,
         )
 
     def test_read_manager_multiple_responsibilities(self):

--- a/backend/tests/test_integration_org_unit.py
+++ b/backend/tests/test_integration_org_unit.py
@@ -7,10 +7,10 @@
 #
 
 import unittest
-from unittest.mock import patch
 
 import freezegun
 import notsouid
+from unittest.mock import patch
 
 from mora import lora
 from . import util
@@ -1631,47 +1631,6 @@ class Tests(util.LoRATestCase):
         actual = c.organisationenhed.get(org_unit_uuid)
 
         self.assertRegistrationsEqual(expected, actual)
-
-    def test_edit_org_unit_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        org_unit_uuid = '85715fc7-925d-401b-822d-467eb4b163b6'
-
-        req = [{
-            "type": "org_unit",
-            "data": {
-                "uuid": org_unit_uuid,
-                "org_unit_type": {
-                    'uuid': "79e15798-7d6d-4e85-8496-dcc8887a1c1a"
-                },
-                "validity": {
-                    "from": "2000-01-01",
-                },
-            },
-        }]
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2000-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400,
-        )
-
-        self.assertRequestResponse(
-            '/service/details/edit?force=1',
-            [
-                org_unit_uuid,
-            ],
-            json=req,
-            amqp_topics={'org_unit.org_unit.update': 1},
-        )
 
     @notsouid.freeze_uuid('ec93e37e-774e-40b4-953c-05ca41b80372')
     def test_create_missing_parent(self):

--- a/backend/tests/test_integration_related_units.py
+++ b/backend/tests/test_integration_related_units.py
@@ -9,9 +9,7 @@
 import freezegun
 
 from mora import util as mora_util
-
 from . import util
-
 
 HUM = {
     'org_unit': [
@@ -120,11 +118,11 @@ class Tests(util.LoRATestCase):
             self.assertRequestResponse(
                 '/service/ou/2874e1dc-85e6-4269-823a-e1125484dfd3/map',
                 {
-                    'description':
-                    'Cannot perform changes before current date',
+                    'description': 'Date range exceeds validity range '
+                                   'of associated org unit.',
                     'error': True,
-                    'error_key': 'V_CHANGING_THE_PAST',
-                    'date': '2017-03-01T00:00:00+01:00',
+                    'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
+                    'org_unit_uuid': ['da77153e-30f3-4dc2-a611-ee912a28d8aa'],
                     'status': 400,
                 },
                 json={

--- a/backend/tests/test_integration_role.py
+++ b/backend/tests/test_integration_role.py
@@ -9,7 +9,6 @@
 import freezegun
 
 from mora import lora
-
 from . import util
 
 
@@ -1021,34 +1020,6 @@ class Tests(util.LoRATestCase):
         actual_role = c.organisationfunktion.get(role_uuid)
 
         self.assertRegistrationsEqual(expected_role, actual_role)
-
-    def test_edit_role_in_the_past_fails(self):
-        """It shouldn't be possible to perform an edit in the past"""
-        self.load_sample_structures()
-
-        role_uuid = '1b20d0b9-96a0-42a6-b196-293bb86e62e8'
-
-        req = [{
-            "type": "role",
-            "uuid": role_uuid,
-            "data": {
-                "validity": {
-                    "from": "2000-01-01",
-                },
-            },
-        }]
-
-        self.assertRequestResponse(
-            '/service/details/edit',
-            {
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'date': '2000-01-01T00:00:00+01:00',
-                'status': 400
-            },
-            json=req,
-            status_code=400)
 
     def test_terminate_role(self):
         self.load_sample_structures()

--- a/backend/tests/test_integration_termination.py
+++ b/backend/tests/test_integration_termination.py
@@ -11,7 +11,6 @@ import copy
 import freezegun
 
 from mora import lora
-
 from . import util
 
 
@@ -107,31 +106,6 @@ class Tests(util.LoRATestCase):
         with self.subTest('manager'):
             self.assertRegistrationsEqual(expected_manager,
                                           actual_manager)
-
-    @freezegun.freeze_time('2018-01-01')
-    def test_terminate_employee_in_the_past_fails(self):
-        """Terminating employees in the past should fail"""
-        self.load_sample_structures()
-
-        userid = "53181ed2-f1de-4c4a-a8fd-ab358c2c454a"
-
-        payload = {
-            "validity": {
-                "to": "2000-12-01"
-            }
-        }
-
-        self.assertRequestResponse(
-            '/service/e/{}/terminate'.format(userid),
-            {
-                'date': '2000-12-02T00:00:00+01:00',
-                'description': 'Cannot perform changes before current date',
-                'error': True,
-                'error_key': 'V_CHANGING_THE_PAST',
-                'status': 400
-            },
-            status_code=400,
-            json=payload)
 
     @freezegun.freeze_time('2000-12-01')
     def test_terminate_employee_manager_full(self):

--- a/backend/tests/test_validator.py
+++ b/backend/tests/test_validator.py
@@ -6,13 +6,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-import datetime
 import unittest
 
+import datetime
 import freezegun
 import requests_mock
 
-from mora import lora, exceptions
+from mora import lora
 from mora import settings
 from mora import util as mora_util
 from mora.service.validation import validator
@@ -181,37 +181,3 @@ class TestGetEndpointDate(unittest.TestCase):
         self.startdate = datetime.datetime(
             2017, 1, 1, 0, 0, 0,
             tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
-
-
-@freezegun.freeze_time("2017-01-01")
-class TestIsEditDateBeforeToday(util.TestCase):
-
-    def test_past_dates_raises_exception(self):
-        """Assert that using a date before today raises an exception"""
-
-        test_date = datetime.datetime(
-            2016, 12, 31, 0, 0, 0,
-            tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
-
-        with self.assertRaises(exceptions.HTTPException):
-            validator.is_edit_from_date_before_today(test_date)
-
-    def test_today_does_not_raise_exception(self):
-        """Assert that today's date does not raise an exception"""
-
-        test_date = datetime.datetime(
-            2017, 1, 1, 0, 0, 0,
-            tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
-
-        # We expect this method to not raise an exception
-        validator.is_edit_from_date_before_today(test_date)
-
-    def test_future_date_does_not_raise_exception(self):
-        """Assert that a future date does not raise an exception"""
-
-        test_date = datetime.datetime(
-            2020, 1, 1, 0, 0, 0,
-            tzinfo=datetime.timezone(datetime.timedelta(0), '+00:00'))
-
-        # We expect this method to not raise an exception
-        validator.is_edit_from_date_before_today(test_date)

--- a/frontend/src/components/MoEntryEditModal.vue
+++ b/frontend/src/components/MoEntryEditModal.vue
@@ -22,7 +22,6 @@
         :disable-org-unit-picker="disableOrgUnitPicker"
         :hide-org-picker="hideOrgPicker"
         :hide-employee-picker="hideEmployeePicker"
-        :disabled-dates="disabledDates"
         :is-edit="true"
       />
 
@@ -146,15 +145,6 @@ export default {
      */
     hasEntryComponent () {
       return this.entryComponent !== undefined
-    },
-
-    /**
-     * The valid dates for the entry component date pickers
-     */
-    disabledDates () {
-      return {
-        'from': new Date().toISOString().substring(0, 10)
-      }
     }
   },
 


### PR DESCRIPTION
I basically undid the specific changes made in the previous feature.
I've also optimized imports in the files I touched.

https://redmine.magenta-aps.dk/issues/32476

**Please ensure the following is true:**

- [x] The application can be built and installed without errors
- [x] The feature/bugfix has been tested manually (if manually testable)
- [x] Tests have been written/updated for my change
- [ ] The documentation has been updated
    - [ ] The documentation builds without warnings or errors
- [x] Release notes have been updated
- [x] The corresponding Redmine ticket has been set to `Needs review`
    - [x] The issue has a link to this PR

**If applicable:**

- [ ] Changes have been made to the UI
    - [ ] Screenshots of relevant changes to UI added to PR
- [ ] The API/data model has been changed/expanded
    - [ ] Redmine tickets have been created to update dependent systems
- [ ] The feature introduces changes relevant to the deployment process
    - [ ] Redmine tickets have been created to update deployment process
- [ ] This change affects the development workflow.
    - [ ] I have notified other developers by email or chat.

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
